### PR TITLE
Fix JPA mapping conflicts in embedded Organisation components

### DIFF
--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/domain/customer/entity/Asset.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/domain/customer/entity/Asset.java
@@ -88,6 +88,12 @@ public abstract class Asset implements Serializable {
      * Electronic address.
      */
     @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "email1", column = @Column(name = "asset_email1")),
+        @AttributeOverride(name = "email2", column = @Column(name = "asset_email2")),
+        @AttributeOverride(name = "web", column = @Column(name = "asset_web")),
+        @AttributeOverride(name = "radio", column = @Column(name = "asset_radio"))
+    })
     private Organisation.ElectronicAddress electronicAddress;
 
     /**

--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/domain/customer/entity/EndDeviceEntity.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/domain/customer/entity/EndDeviceEntity.java
@@ -97,6 +97,12 @@ public class EndDeviceEntity extends IdentifiedObject {
      * Electronic address.
      */
     @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "email1", column = @Column(name = "end_device_email1")),
+        @AttributeOverride(name = "email2", column = @Column(name = "end_device_email2")),
+        @AttributeOverride(name = "web", column = @Column(name = "end_device_web")),
+        @AttributeOverride(name = "radio", column = @Column(name = "end_device_radio"))
+    })
     private Organisation.ElectronicAddress electronicAddress;
 
     /**

--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/domain/customer/entity/Location.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/domain/customer/entity/Location.java
@@ -59,10 +59,11 @@ public abstract class Location implements Serializable {
      */
     @Embedded
     @AttributeOverrides({
-        @AttributeOverride(name = "poBox", column = @Column(name = "main_po_box")),
-        @AttributeOverride(name = "street", column = @Column(name = "main_street")),
-        @AttributeOverride(name = "streetSuffix", column = @Column(name = "main_street_suffix")),
-        @AttributeOverride(name = "suite", column = @Column(name = "main_suite"))
+        @AttributeOverride(name = "streetDetail", column = @Column(name = "location_main_street_detail")),
+        @AttributeOverride(name = "townDetail", column = @Column(name = "location_main_town_detail")),
+        @AttributeOverride(name = "stateOrProvince", column = @Column(name = "location_main_state_or_province")),
+        @AttributeOverride(name = "postalCode", column = @Column(name = "location_main_postal_code")),
+        @AttributeOverride(name = "country", column = @Column(name = "location_main_country"))
     })
     private Organisation.StreetAddress mainAddress;
 
@@ -71,10 +72,11 @@ public abstract class Location implements Serializable {
      */
     @Embedded
     @AttributeOverrides({
-        @AttributeOverride(name = "poBox", column = @Column(name = "secondary_po_box")),
-        @AttributeOverride(name = "street", column = @Column(name = "secondary_street")),
-        @AttributeOverride(name = "streetSuffix", column = @Column(name = "secondary_street_suffix")),
-        @AttributeOverride(name = "suite", column = @Column(name = "secondary_suite"))
+        @AttributeOverride(name = "streetDetail", column = @Column(name = "location_secondary_street_detail")),
+        @AttributeOverride(name = "townDetail", column = @Column(name = "location_secondary_town_detail")),
+        @AttributeOverride(name = "stateOrProvince", column = @Column(name = "location_secondary_state_or_province")),
+        @AttributeOverride(name = "postalCode", column = @Column(name = "location_secondary_postal_code")),
+        @AttributeOverride(name = "country", column = @Column(name = "location_secondary_country"))
     })
     private Organisation.StreetAddress secondaryAddress;
 
@@ -86,10 +88,10 @@ public abstract class Location implements Serializable {
      */
     @Embedded
     @AttributeOverrides({
-        @AttributeOverride(name = "email1", column = @Column(name = "electronic_email1")),
-        @AttributeOverride(name = "email2", column = @Column(name = "electronic_email2")),
-        @AttributeOverride(name = "web", column = @Column(name = "electronic_web")),
-        @AttributeOverride(name = "radio", column = @Column(name = "electronic_radio"))
+        @AttributeOverride(name = "email1", column = @Column(name = "location_email1")),
+        @AttributeOverride(name = "email2", column = @Column(name = "location_email2")),
+        @AttributeOverride(name = "web", column = @Column(name = "location_web")),
+        @AttributeOverride(name = "radio", column = @Column(name = "location_radio"))
     })
     private Organisation.ElectronicAddress electronicAddress;
 


### PR DESCRIPTION
## Summary
- Add missing @AttributeOverrides for Asset.electronicAddress with "asset_" prefix
- Add missing @AttributeOverrides for EndDeviceEntity.electronicAddress with "end_device_" prefix  
- Add complete @AttributeOverrides for Location @MappedSuperclass with "location_" prefix
- Resolves major JPA column mapping conflicts preventing Spring Boot 3.5 migration

## Changes
- **Asset.java**: Added AttributeOverrides for embedded Organisation.ElectronicAddress
- **EndDeviceEntity.java**: Added AttributeOverrides for embedded Organisation.ElectronicAddress
- **Location.java**: Added complete AttributeOverrides for mainAddress, secondaryAddress, and electronicAddress

## Test plan
- [x] Code compiles successfully
- [x] MapStruct regenerates mappers without errors
- [x] Application startup progresses significantly further
- [ ] Remaining CustomerAccountEntity issue to be addressed in separate PR

🤖 Generated with [Claude Code](https://claude.ai/code)