### PR TITLE
fix: upgrade MySQL Connector to fix CVE-2023-22102

### DIFF
--- a/openespi-common/pom.xml
+++ b/openespi-common/pom.xml
@@ -409,9 +409,9 @@
 
 <!--        add dependency for mysql-->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.32</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>9.1.0</version>
             <scope>test</scope>
         </dependency>
         


### PR DESCRIPTION
## Summary
- Fixes CVE-2023-22102: High severity MySQL Connectors takeover vulnerability
- Replaces deprecated `mysql:mysql-connector-java` with `com.mysql:mysql-connector-j`
- Upgrades from 8.0.32 (vulnerable) to 9.1.0 (secure)
- Aligns openespi-common with datacustodian and thirdparty modules

## Changes
- **openespi-common/pom.xml**: Updated MySQL connector dependency
  - GroupId: `mysql` → `com.mysql`
  - ArtifactId: `mysql-connector-java` → `mysql-connector-j`
  - Version: `8.0.32` → `9.1.0`

## Security Impact
- **CVE**: CVE-2023-22102
- **GHSA**: GHSA-m6vm-37g8-gqvh
- **Severity**: High
- **Description**: Difficult to exploit vulnerability allows unauthenticated attacker with network access to compromise MySQL Connectors, potentially resulting in takeover
- **Vulnerable versions**: ≤ 8.0.33
- **Fixed version**: 9.1.0

## Testing
- ✓ All openespi-common tests pass
- ✓ Build successful
- ✓ No breaking changes detected

## Related
- Resolves Dependabot alert #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)