### PR TITLE
refactor: remove minimum required fields constructor from ApplicationInformationDto

### DIFF
--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/dto/usage/ApplicationInformationDto.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/dto/usage/ApplicationInformationDto.java
@@ -202,6 +202,8 @@ public record ApplicationInformationDto(
 
     /**
      * Default constructor for JAXB.
+     * Creates an ApplicationInformationDto with all fields set to null.
+     * The canonical constructor with all fields is automatically provided by the record declaration.
      */
     public ApplicationInformationDto() {
         this(null, null, null, null, null, null, null, null, null,
@@ -209,17 +211,6 @@ public record ApplicationInformationDto(
              null, null, null, null, null, null, null, null, null,
              null, null, null, null, null, null, null, null, null,
              null);
-    }
-
-    /**
-     * Constructor for basic application information (minimum required fields).
-     */
-    public ApplicationInformationDto(String dataCustodianId, String clientId, String clientSecret, String clientName) {
-        this(null, dataCustodianId, null, null, null, null, null, null, null,
-             null, null, null, null, null, null, null, null, null,
-             clientSecret, null, clientName, null, null, clientId, null, null,
-             null, null, null, null, null, null, null, null, null,
-             null, null);
     }
 
     // JAXB property accessors - must match propOrder sequence


### PR DESCRIPTION
## Summary

Removed the 4-parameter convenience constructor from `ApplicationInformationDto` that only accepted `dataCustodianId`, `clientId`, `clientSecret`, and `clientName`.

## Changes

- **Removed**: 4-parameter constructor (lines 217-223)
- **Retained**: 
  - Default no-arg constructor (required for JAXB)
  - Canonical constructor with all 37 fields (auto-generated by Java record)
- **Updated**: Javadoc for default constructor to clarify canonical constructor availability

## Rationale

- Simplifies the DTO by reducing constructor options
- The minimum required fields constructor was not used anywhere in the codebase
- Encourages use of the canonical constructor to ensure all required fields are properly set
- Prevents partial initialization that could lead to incomplete data

## Testing

- ✅ All 18 integration tests passing:
  - H2: 6 tests
  - MySQL: 6 tests  
  - PostgreSQL: 6 tests
- ✅ Build verified successful with no errors
- ✅ No breaking changes - constructor was unused in codebase

## Impact

- **Breaking Change**: No (constructor was not in use)
- **API Change**: Yes (removes a public constructor)
- **Migration Required**: No

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)