### PR TITLE
fix: correct index mapping in electric_power_quality_summaries table

### DIFF
--- a/openespi-common/src/main/resources/db/migration/V3__Create_additiional_Base_Tables.sql
+++ b/openespi-common/src/main/resources/db/migration/V3__Create_additiional_Base_Tables.sql
@@ -641,7 +641,7 @@ CREATE TABLE electric_power_quality_summaries
 );
 
 CREATE INDEX idx_epqs_usage_point_id ON electric_power_quality_summaries (usage_point_id);
-CREATE INDEX idx_epqs_summary_interval_start ON electric_power_quality_summaries (id);
+CREATE INDEX idx_epqs_summary_interval_start ON electric_power_quality_summaries (summary_interval_start);
 CREATE INDEX idx_epqs_created ON electric_power_quality_summaries (created);
 CREATE INDEX idx_epqs_updated ON electric_power_quality_summaries (updated);
 


### PR DESCRIPTION
## Summary

Fixes incorrect index mapping in the `electric_power_quality_summaries` table where `idx_epqs_summary_interval_start` was indexing the `id` column instead of the `summary_interval_start` column.

## Root Cause

This issue was introduced in commit d5e321bf when uuid columns were removed and replaced with id PRIMARY KEY columns. During the migration, one index was incorrectly remapped:

**Before (incorrect)**:
```sql
CREATE INDEX idx_epqs_summary_interval_start ON electric_power_quality_summaries (uuid);
```

**After uuid removal (still incorrect)**:
```sql
CREATE INDEX idx_epqs_summary_interval_start ON electric_power_quality_summaries (id);
```

**Fixed (correct)**:
```sql
CREATE INDEX idx_epqs_summary_interval_start ON electric_power_quality_summaries (summary_interval_start);
```

## Changes

- **File Modified**: `openespi-common/src/main/resources/db/migration/V3__Create_additiional_Base_Tables.sql`
- **Line**: 644
- **Change**: Index now correctly points to `summary_interval_start` column

## Analysis of UUID Index Removals

Commit d5e321bf removed 25 uuid indexes across V1 and V3 migrations:
- ✅ **24 removals were correct**: All tables have `id CHAR(36) PRIMARY KEY` which automatically creates an index
- ❌ **1 bug found**: `idx_epqs_summary_interval_start` was indexing wrong column

## Testing

- ✅ All H2 repository tests passing (60+ tests)
- ✅ Flyway migrations V1, V2, V3 execute successfully  
- ✅ Index now correctly targets `summary_interval_start` column
- ⚠️ TestContainers integration tests skipped due to Docker Desktop 29.1.3 compatibility issue (unrelated to this fix)

## Impact

Queries filtering by `summary_interval_start` will now properly use this index for improved performance.

## Related Issues

**TestContainers Issue** (not addressed in this PR):
- TestContainers 1.20.1 has compatibility issues with Docker Desktop 29.1.3
- This is an environmental issue separate from the index fix
- Recommend creating a separate issue for investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)