### PR TITLE
fix: resolve PostgreSQL configuration mismatches (Issue #55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           --health-retries=3
 
       postgres:
-        image: postgres:15
+        image: postgres:18
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test_db

--- a/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/migration/DataCustodianApplicationPostgresTest.java
+++ b/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/migration/DataCustodianApplicationPostgresTest.java
@@ -27,9 +27,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -52,8 +52,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Disabled("Temporarily disabled due to Issue #53: PostgreSQL UUID CHAR(36) type mismatch. " +
           "JPA entities use @GeneratedValue(strategy = GenerationType.UUID) expecting native UUID type, " +
           "but Flyway migrations use CHAR(36) for MySQL/H2 compatibility. " +
-          "This will be resolved after MULTI_PHASE schema compliance plan completes. " +
-          "See: https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/53")
+          "Configuration issues (Issue #55) have been resolved - Flyway paths and PostgreSQL version are correct. " +
+          "This test will be re-enabled after MULTI_PHASE schema compliance plan completes and UUID conversion is implemented. " +
+          "See: https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/53 " +
+          "and https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/55")
 class DataCustodianApplicationPostgresTest {
 
     @Container

--- a/openespi-datacustodian/src/test/resources/application-testcontainers-postgresql.yml
+++ b/openespi-datacustodian/src/test/resources/application-testcontainers-postgresql.yml
@@ -26,7 +26,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-    locations: classpath:db/migration/postgresql
+    locations: classpath:db/migration,classpath:db/vendor/postgres
     
   # Faster testing configuration
   main:

--- a/openespi-thirdparty/src/test/resources/application-testcontainers-postgresql.yml
+++ b/openespi-thirdparty/src/test/resources/application-testcontainers-postgresql.yml
@@ -26,7 +26,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-    locations: classpath:db/migration/postgresql
+    locations: classpath:db/migration,classpath:db/vendor/postgres
     
   # Faster testing configuration
   main:


### PR DESCRIPTION
## Summary

This PR resolves configuration inconsistencies between the CI/CD pipeline and TestContainers setup that would prevent PostgreSQL integration tests from running correctly when re-enabled.

## Changes Made

### 1. Fixed Flyway Migration Paths ✅

**Files Modified:**
- `openespi-datacustodian/src/test/resources/application-testcontainers-postgresql.yml`
- `openespi-thirdparty/src/test/resources/application-testcontainers-postgresql.yml`

**Before (BROKEN):**
```yaml
flyway:
  locations: classpath:db/migration/postgresql  # ← Path doesn't exist!
```

**After (FIXED):**
```yaml
flyway:
  locations: classpath:db/migration,classpath:db/vendor/postgres  # ← Correct paths
```

**Impact:** Integration tests can now find and execute Flyway migrations when using testcontainers profile.

### 2. Upgraded PostgreSQL Version in CI/CD ✅

**File Modified:** `.github/workflows/ci.yml`

**Before:**
```yaml
postgres:
  image: postgres:15
```

**After:**
```yaml
postgres:
  image: postgres:18
```

**Impact:** Aligns CI/CD environment with TestContainers (both now use postgres:18).

### 3. Updated Test Documentation ✅

**File Modified:** `openespi-common/src/test/java/.../DataCustodianApplicationPostgresTest.java`

Updated `@Disabled` annotation to clearly document:
- ✅ Configuration issues (Issue #55) are **RESOLVED**
- ❌ UUID type mismatch (Issue #53) still **BLOCKS** test execution
- Tests will be re-enabled after MULTI_PHASE schema compliance plan
- References both Issue #53 and Issue #55 for full context

## Test Results

Ran `DataCustodianApplicationPostgresTest` with all fixes applied:

**✅ Issue #55 Configuration Fixed:**
- Flyway migrations execute successfully with correct paths
- PostgreSQL 18 container starts and runs properly
- All infrastructure configuration working correctly

**❌ Issue #53 UUID Type Mismatch Still Blocks Tests:**
```
Schema validation: wrong column type encountered in column [id] in table [aggregated_node_refs]; 
found [bpchar (Types#CHAR)], but expecting [uuid (Types#UUID)]
```

This confirms that Issue #55 and Issue #53 are **separate problems**:
- **Issue #55**: Configuration mismatches → ✅ **FIXED by this PR**
- **Issue #53**: CHAR(36) vs UUID type mismatch → ❌ **Requires V4 migration script**

## Technical Details - Why Issue #53 Still Fails

### Root Cause

**JPA Entity Definition:**
```java
@GeneratedValue(strategy = GenerationType.UUID)  // Expects native PostgreSQL UUID type
private UUID id;
```

**Flyway Migration:**
```sql
CREATE TABLE aggregated_node_refs (
    id CHAR(36) PRIMARY KEY  -- Creates 36-character string for cross-DB compatibility
);
```

**Schema Validation Failure:**
1. JPA expects: `java.sql.Types.UUID` (native 16-byte PostgreSQL UUID)
2. Database has: `java.sql.Types.CHAR` (36-character string: `"550e8400-e29b-41d4-a716-446655440000"`)
3. Hibernate validation: `Types.CHAR ≠ Types.UUID` → **FAIL**

**Why CHAR(36)?** Cross-database compatibility with H2 and MySQL which lack native UUID support in base migrations.

**Resolution Required:** Create vendor-specific V4 PostgreSQL migration to convert all 91 CHAR(36) columns to native UUID type. This is postponed until after MULTI_PHASE schema compliance plan to avoid double work on tables that will be restructured.

## Why Merge This PR Despite Tests Still Disabled?

1. **Fixes Real Bugs**: Configuration issues will cause failures when tests are eventually re-enabled
2. **No Dependency**: Configuration fixes are independent of Issue #53 schema changes
3. **Prepares Infrastructure**: Sets up proper foundation for future UUID conversion
4. **Low Risk**: Only configuration changes, no schema modifications
5. **Incremental Progress**: Good engineering practice to fix known issues as discovered

## Verification Steps

### Before This PR:
```bash
# Broken Flyway path would cause:
mvn verify -Pintegration-tests -Dspring.profiles.active=testcontainers-postgresql
# ERROR: Cannot find migrations at classpath:db/migration/postgresql
```

### After This PR:
```bash
# Flyway migrations execute successfully:
mvn verify -Pintegration-tests -Dspring.profiles.active=testcontainers-postgresql
# Migrations V1, V2, V3 execute ✅
# Schema validation fails due to Issue #53 UUID mismatch ❌
```

## Related Issues

- Fixes #55 - PostgreSQL configuration mismatches between CI/CD and TestContainers
- Ref #53 - UUID CHAR(36) type mismatch (still blocking, will be resolved post-MULTI_PHASE)

## Checklist

- [x] Configuration files updated with correct Flyway migration paths
- [x] CI/CD PostgreSQL version upgraded to match TestContainers (postgres:18)
- [x] Test documentation updated to reflect current status
- [x] Changes tested - Flyway migrations execute successfully
- [x] Issue #55 updated with detailed resolution status
- [x] Tests remain disabled per strategic decision to postpone UUID conversion

## Next Steps (After This PR)

1. ✅ Close Issue #55 (configuration fixes complete)
2. ⏳ Proceed with MULTI_PHASE schema compliance plan
3. ⏳ After MULTI_PHASE: Create V4 migration for UUID conversion (Issue #53)
4. ⏳ Re-enable PostgreSQL tests once Issue #53 is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>