### PR TITLE
feat: ESPI 4.0 Schema Compliance - Phase 16c: UsagePoint Repository Cleanup

### DIFF
--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/repositories/usage/UsagePointRepository.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/repositories/usage/UsagePointRepository.java
@@ -35,57 +35,56 @@ import java.util.UUID;
 /**
  * Modern Spring Data JPA repository for UsagePoint entities.
  * Replaces the legacy UsagePointRepositoryImpl with modern Spring Data patterns.
+ * <p>
+ * Phase 16c Repository Cleanup:
+ * - Removed queries on non-indexed columns (uri)
+ * - Removed full table scan queries (findAllIds)
+ * - Converted @Query to Spring Data JPA derived queries where possible
+ * - Use built-in JpaRepository methods (existsById, deleteById) instead of custom queries
+ * - All remaining queries use indexed columns for optimal performance
  */
 @Repository
 public interface UsagePointRepository extends JpaRepository<UsagePointEntity, UUID> {
 
     /**
      * Find all usage points for a specific retail customer.
+     * Uses indexed column: retail_customer_id
+     * Converted to Spring Data JPA derived query method (Phase 16c).
+     *
+     * @param retailCustomerId the retail customer ID
+     * @return list of usage points for the customer
      */
-    @Query("SELECT up FROM UsagePointEntity up WHERE up.retailCustomer.id = :retailCustomerId")
-    List<UsagePointEntity> findAllByRetailCustomerId(@Param("retailCustomerId") Long retailCustomerId);
-
-    /**
-     * Find usage point by resource URI.
-     */
-    @Query("SELECT up FROM UsagePointEntity up WHERE up.uri = :uri")
-    Optional<UsagePointEntity> findByResourceUri(@Param("uri") String uri);
+    List<UsagePointEntity> findAllByRetailCustomerId(Long retailCustomerId);
 
     /**
      * Find usage point by related href.
+     * Uses indexed relationship: usage_point_related_links(usage_point_id)
+     *
+     * @param href the related link href
+     * @return optional usage point matching the href
      */
     @Query("SELECT up FROM UsagePointEntity up JOIN up.relatedLinks rl WHERE rl.href = :href")
     Optional<UsagePointEntity> findByRelatedHref(@Param("href") String href);
 
     /**
      * Find all usage points updated after a given timestamp.
+     * Uses indexed column: updated
+     *
+     * @param lastUpdate the last update timestamp
+     * @return list of usage points updated after the given time
      */
-    @Query("SELECT up FROM UsagePointEntity up WHERE up.updated > :lastUpdate")
-    List<UsagePointEntity> findAllUpdatedAfter(@Param("lastUpdate") LocalDateTime lastUpdate);
+    List<UsagePointEntity> findAllByUpdatedAfter(LocalDateTime lastUpdate);
 
     /**
      * Find all usage point IDs for a specific retail customer.
+     * Uses indexed column: retail_customer_id
+     *
+     * @param retailCustomerId the retail customer ID
+     * @return list of usage point IDs for the customer
      */
     @Query("SELECT up.id FROM UsagePointEntity up WHERE up.retailCustomer.id = :retailCustomerId")
     List<UUID> findAllIdsByRetailCustomerId(@Param("retailCustomerId") Long retailCustomerId);
 
-    /**
-     * Find all usage point IDs.
-     */
-    @Query("SELECT up.id FROM UsagePointEntity up")
-    List<UUID> findAllIds();
-
-    /**
-     * Check if usage point exists by UUID.
-     */
-    @Query("SELECT COUNT(up) > 0 FROM UsagePointEntity up WHERE up.id = :uuid")
-    boolean existsByUuid(@Param("uuid") UUID uuid);
-
-    /**
-     * Delete usage point by UUID.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM UsagePointEntity up WHERE up.id = :uuid")
-    void deleteByUuid(@Param("uuid") UUID uuid);
+    // Note: Use built-in existsById(UUID id) instead of custom existsByUuid
+    // Note: Use built-in deleteById(UUID id) instead of custom deleteByUuid
 }

--- a/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/repositories/usage/UsagePointRepositoryTest.java
+++ b/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/repositories/usage/UsagePointRepositoryTest.java
@@ -287,24 +287,7 @@ class UsagePointRepositoryTest extends BaseRepositoryTest {
                     .contains("Customer 2 Usage Point");
         }
 
-        @Test
-        @DisplayName("Should find usage point by resource URI")
-        void shouldFindUsagePointByResourceUri() {
-            // Arrange
-            UsagePointEntity usagePoint = TestDataBuilders.createValidUsagePoint();
-            usagePoint.setDescription("Usage Point with URI");
-            usagePoint.setUri("/espi/1_1/resource/UsagePoint/123");
-            usagePointRepository.save(usagePoint);
-            flushAndClear();
-
-            // Act
-            Optional<UsagePointEntity> result = usagePointRepository.findByResourceUri("/espi/1_1/resource/UsagePoint/123");
-
-            // Assert
-            assertThat(result).isPresent();
-            assertThat(result.get().getDescription()).isEqualTo("Usage Point with URI");
-            assertThat(result.get().getUri()).isEqualTo("/espi/1_1/resource/UsagePoint/123");
-        }
+        // Phase 16c: Removed test for findByResourceUri (method removed - uri not indexed, legacy field)
 
         @Test
         @DisplayName("Should find usage point by related href")
@@ -355,7 +338,7 @@ class UsagePointRepositoryTest extends BaseRepositoryTest {
             flushAndClear();
 
             // Act
-            List<UsagePointEntity> results = usagePointRepository.findAllUpdatedAfter(cutoffTime);
+            List<UsagePointEntity> results = usagePointRepository.findAllByUpdatedAfter(cutoffTime);
 
             // Assert - Should find at least the recent usage point
             assertThat(results).isNotEmpty();
@@ -386,69 +369,18 @@ class UsagePointRepositoryTest extends BaseRepositoryTest {
             assertThat(usagePointIds).contains(savedUsagePoints.get(0).getId(), savedUsagePoints.get(1).getId());
         }
 
-        @Test
-        @DisplayName("Should find all usage point IDs")
-        void shouldFindAllUsagePointIds() {
-            // Arrange
-            long initialCount = usagePointRepository.count();
-            List<UsagePointEntity> usagePoints = TestDataBuilders.createValidEntities(3, TestDataBuilders::createValidUsagePoint);
-            List<UsagePointEntity> savedUsagePoints = usagePointRepository.saveAll(usagePoints);
-            flushAndClear();
-
-            // Act
-            List<UUID> allIds = usagePointRepository.findAllIds();
-
-            // Assert
-            assertThat(allIds).hasSizeGreaterThanOrEqualTo(3);
-            assertThat(allIds).contains(
-                    savedUsagePoints.get(0).getId(),
-                    savedUsagePoints.get(1).getId(),
-                    savedUsagePoints.get(2).getId()
-            );
-        }
-
-        @Test
-        @DisplayName("Should check if usage point exists by UUID")
-        void shouldCheckIfUsagePointExistsByUuid() {
-            // Arrange
-            UsagePointEntity usagePoint = TestDataBuilders.createValidUsagePoint();
-            UsagePointEntity saved = usagePointRepository.save(usagePoint);
-            flushAndClear();
-
-            // Act & Assert
-            assertThat(usagePointRepository.existsByUuid(saved.getId())).isTrue();
-            assertThat(usagePointRepository.existsByUuid(UUID.randomUUID())).isFalse();
-        }
-
-        @Test
-        @DisplayName("Should delete usage point by UUID")
-        void shouldDeleteUsagePointByUuid() {
-            // Arrange
-            UsagePointEntity usagePoint = TestDataBuilders.createValidUsagePoint();
-            usagePoint.setDescription("Usage Point to Delete by UUID");
-            UsagePointEntity saved = usagePointRepository.save(usagePoint);
-            UUID usagePointId = saved.getId();
-            flushAndClear();
-
-            // Verify it exists
-            assertThat(usagePointRepository.existsById(usagePointId)).isTrue();
-
-            // Act
-            usagePointRepository.deleteByUuid(usagePointId);
-            flushAndClear();
-
-            // Assert
-            assertThat(usagePointRepository.existsById(usagePointId)).isFalse();
-        }
+        // Phase 16c: Removed test for findAllIds (method removed - full table scan without WHERE clause)
+        // Phase 16c: Removed test for existsByUuid (use built-in existsById instead)
+        // Phase 16c: Removed test for deleteByUuid (use built-in deleteById instead)
 
         @Test
         @DisplayName("Should handle empty results gracefully")
         void shouldHandleEmptyResultsGracefully() {
-            // Act & Assert
+            // Act & Assert - Test all indexed query methods with non-existent data
             assertThat(usagePointRepository.findAllByRetailCustomerId(999999L)).isEmpty();
-            assertThat(usagePointRepository.findByResourceUri("nonexistent-uri")).isEmpty();
             assertThat(usagePointRepository.findByRelatedHref("nonexistent-href")).isEmpty();
             assertThat(usagePointRepository.findAllIdsByRetailCustomerId(999999L)).isEmpty();
+            assertThat(usagePointRepository.findAllByUpdatedAfter(java.time.LocalDateTime.now())).isEmpty();
         }
     }
 


### PR DESCRIPTION
## Summary
This PR implements Phase 16c of the UsagePoint schema compliance work, cleaning up the repository to remove non-indexed queries and convert to Spring Data JPA derived query methods for optimal performance.

## Phase 16 Strategy
Phase 16 (UsagePoint) is being split into sub-phases:
- **Phase 16a** (PR #83): Add missing Boolean/String fields ✅ MERGED
- **Phase 16b** (PR #84): Add enum fields + reorder fields to match XSD ✅ MERGED
- **Phase 16c** (THIS PR): Repository cleanup ✅
- **Phase 16d**: Mapper bidirectional updates
- **Phase 16e**: XML schema validation tests

## Changes in Phase 16c

### 🗑️ Removed Methods (Non-Indexed or Redundant)

| Method | Reason for Removal |
|--------|-------------------|
| `findByResourceUri(String uri)` | Queries `uri` field which is NOT indexed AND is a legacy field NOT in ESPI 4.0 XSD |
| `findAllIds()` | Full table scan without WHERE clause - performance risk |
| `existsByUuid(UUID uuid)` | Use built-in `existsById(UUID id)` instead |
| `deleteByUuid(UUID uuid)` | Use built-in `deleteById(UUID id)` instead |

### ✅ Retained Methods (All Use Indexed Columns)

| Method | Indexed Column Used | Notes |
|--------|---------------------|-------|
| `findAllByRetailCustomerId(Long)` | `retail_customer_id` | Converted to Spring Data JPA derived query |
| `findAllByUpdatedAfter(LocalDateTime)` | `updated` | Converted to Spring Data JPA derived query |
| `findByRelatedHref(String)` | `usage_point_related_links(usage_point_id)` | Uses indexed relationship table |
| `findAllIdsByRetailCustomerId(Long)` | `retail_customer_id` | Custom JPQL for ID-only projection |

### 📊 Database Index Analysis

Current indexed columns on `usage_points` table:

| Column | Indexed | In XSD? | Used by Queries? |
|--------|---------|---------|------------------|
| `kind` | ✅ | ❌ | ❌ (candidate for removal) |
| `status` | ✅ | ✅ | ❌ |
| `retail_customer_id` | ✅ | ✅ | ✅ |
| `service_delivery_point_id` | ✅ | ✅ | ❌ |
| `local_time_parameters_id` | ✅ | ✅ | ❌ |
| `created` | ✅ | ✅ | ❌ |
| `updated` | ✅ | ✅ | ✅ |

**Key Findings:**
- `kind` field: Indexed but NOT in ESPI 4.0 XSD (legacy field, no queries use it)
- `uri` field: Not indexed, NOT in ESPI 4.0 XSD (legacy field, removed from queries)

### 🧪 Test Updates

**Removed 4 test methods** for deleted repository methods:
- `shouldFindUsagePointByResourceUri()`
- `shouldFindAllUsagePointIds()`
- `shouldCheckIfUsagePointExistsByUuid()`
- `shouldDeleteUsagePointByUuid()`

**Updated tests:**
- `shouldHandleEmptyResultsGracefully()` - Removed references to deleted methods
- `shouldFindAllUsagePointsUpdatedAfterTimestamp()` - Updated method call to `findAllByUpdatedAfter()`

## Technical Details

### Performance Benefits
- ✅ Eliminates full table scans (removed `findAllIds`)
- ✅ All queries use database indexes for O(log n) lookups instead of O(n) scans
- ✅ Removes queries on non-indexed legacy field (`uri`)

### Spring Data JPA Patterns
- Derived query methods (e.g., `findAllByRetailCustomerId`) are automatically implemented by Spring Data JPA at runtime
- Reduces custom JPQL code and improves maintainability
- Type-safe method names reduce query errors
- Example: `findAllByRetailCustomerId` → Spring generates `SELECT ... WHERE retail_customer_id = ?`

### Repository Documentation
Added comprehensive JavaDoc to repository interface explaining:
- Phase 16c cleanup rationale
- Which columns are indexed
- Why certain methods were removed
- Notes to use built-in JpaRepository methods

## Test Results
```
Tests run: 580, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

**Note:** Was 584 tests, now 580 (removed 4 tests for deleted methods)

## Migration Impact

### ⚠️ Breaking Changes
The following public repository methods have been removed:
- `findByResourceUri(String uri)` - Use alternative approach or migrate away from legacy `uri` field
- `findAllIds()` - Use `findAll()` and extract IDs, or `findAllIdsByRetailCustomerId()` for filtered IDs
- `existsByUuid(UUID uuid)` - Use built-in `existsById(UUID id)` instead
- `deleteByUuid(UUID uuid)` - Use built-in `deleteById(UUID id)` instead

### ✅ No Service Layer Changes Required
Checked all usages in service layer:
- `UsagePointServiceImpl` uses `findAllIdsByRetailCustomerId()` - Still available ✅
- No services were using the removed methods ✅

## Related
- Issue #28 - Phase 16: UsagePoint
- PR #83 - Phase 16a: Add Missing Boolean/String Fields (merged)
- PR #84 - Phase 16b: Add Enum Fields & Reorder (merged)
- Part 3 of 5 sub-phases for complete UsagePoint compliance

## Next Steps (Phase 16d)
- Mapper bidirectional updates
- Update Entity-to-DTO mappings
- Update DTO-to-Entity mappings
- Handle all embedded SummaryMeasurement mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)