### PR TITLE
chore: ignore npm tooling artifacts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ test-output/
 temp-services/
 */temp-services/.claude/settings.local.json
 .claude/settings.local.json
+
+# npm tooling (not part of Maven build)
+node_modules/
+package.json
+package-lock.json


### PR DESCRIPTION
  ## Summary

  Adds `node_modules/`, `package.json`, and `package-lock.json` to `.gitignore`.
  These artifacts appear when running npm-based developer tooling locally (schema
  generators, linters, JSON schema previewers, etc.) and aren’t part of this
  project’s Maven-based build.

  ## Rationale

Without these patterns in `.gitignore`, any contributor who runs an `npm`-based script in the repo root has to manually exclude the resulting artifacts from every commit, or risks accidentally including a multi-megabyte `node_modules/` directory in a PR.  Adding the patterns once eliminates that friction and prevents the most common accidental-commit failure mode for npm tooling.

  ## Scope

  Three new entries in `.gitignore` only.  No build configuration changes, no
  behavioral changes, no impact on tracked files (none of these paths are
  currently tracked in the repo).

  ## Test plan

  - [x] `.gitignore` parses correctly
  - [x] After change, locally running `npm install` produces `node_modules/` that does not appear in `git status.`
  - [ ] CI checks pass (Build and Test, Security Scan, PR Validation)