### PR TITLE
refactor: de-stream REST controllers to remove MockMvc CME flake

### DIFF
--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ApplicationInformationRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ApplicationInformationRESTController.java
@@ -37,9 +37,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
@@ -62,7 +62,7 @@ public class ApplicationInformationRESTController {
     /**
      * Gets all ApplicationInformation resources.
      *
-     * @return StreamingResponseBody for XML output
+     * @return XML response body
      */
     @GetMapping(produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @Operation(
@@ -76,19 +76,21 @@ public class ApplicationInformationRESTController {
         @ApiResponse(responseCode = "403", description = "Forbidden")
     })
     @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or hasAuthority('SCOPE_ThirdParty_Admin_Access')")
-    public ResponseEntity<StreamingResponseBody> getAllApplicationInformation() {
+    public ResponseEntity<byte[]> getAllApplicationInformation() {
         List<ApplicationInformationEntity> entities = applicationInformationService.findAll();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        applicationInformationService.export(entities, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(outputStream -> applicationInformationService.export(entities, outputStream));
+                .body(out.toByteArray());
     }
 
     /**
      * Gets a specific ApplicationInformation resource by ID.
      *
      * @param applicationInformationId Unique identifier for the ApplicationInformation
-     * @return StreamingResponseBody for XML output
+     * @return XML response body
      */
     @GetMapping(value = "/{applicationInformationId}", produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @Operation(
@@ -102,7 +104,7 @@ public class ApplicationInformationRESTController {
         @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or hasAuthority('SCOPE_ThirdParty_Admin_Access')")
-    public ResponseEntity<StreamingResponseBody> getApplicationInformation(
+    public ResponseEntity<byte[]> getApplicationInformation(
             @Parameter(description = "Unique identifier of the ApplicationInformation", required = true)
             @PathVariable UUID applicationInformationId) {
 
@@ -111,9 +113,11 @@ public class ApplicationInformationRESTController {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "ApplicationInformation not found");
         }
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        applicationInformationService.export(entity, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(outputStream -> applicationInformationService.export(entity, outputStream));
+                .body(out.toByteArray());
     }
 
     /**

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerAccountRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerAccountRESTController.java
@@ -40,9 +40,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
@@ -52,7 +52,7 @@ import java.util.UUID;
  * Green Button Alliance ESPI (Energy Services Provider Interface) specification.
  * <p>
  * This controller handles CustomerAccount operations with modern Spring Boot 3.5 patterns,
- * returning DTOs and supporting XML output via StreamingResponseBody.
+ * returning XML output via JAXB-marshalled responses.
  */
 @RestController
 @RequestMapping("/espi/1_1/resource")
@@ -82,7 +82,7 @@ public class CustomerAccountRESTController {
     )
     @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getCustomerAccountCollection(
+    public ResponseEntity<byte[]> getCustomerAccountCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
             @Parameter(description = "Offset for pagination", example = "0")
@@ -92,9 +92,11 @@ public class CustomerAccountRESTController {
                 .map(customerAccountMapper::toDto)
                 .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        customerAccountExportService.exportDto(dtos, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> customerAccountExportService.exportDto(dtos, out));
+                .body(out.toByteArray());
     }
 
     /**
@@ -114,7 +116,7 @@ public class CustomerAccountRESTController {
     )
     @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getCustomerAccount(
+    public ResponseEntity<byte[]> getCustomerAccount(
             @Parameter(description = "Unique identifier of the CustomerAccount", required = true)
             @PathVariable UUID customerAccountId) {
 
@@ -122,9 +124,11 @@ public class CustomerAccountRESTController {
                 .map(customerAccountMapper::toDto)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CustomerAccount not found for id: " + customerAccountId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        customerAccountExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> customerAccountExportService.exportDto(dto, out));
+                .body(out.toByteArray());
     }
 
     /**

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerRESTController.java
@@ -41,9 +41,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
@@ -53,7 +53,7 @@ import java.util.UUID;
  * Green Button Alliance ESPI (Energy Services Provider Interface) specification.
  * <p>
  * This controller handles Customer operations with modern Spring Boot 3.5 patterns,
- * returning DTOs and supporting XML output via StreamingResponseBody.
+ * returning XML output via JAXB-marshalled responses.
  */
 @RestController
 @RequestMapping("/espi/1_1/resource")
@@ -83,7 +83,7 @@ public class CustomerRESTController {
     )
     @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getCustomerCollection(
+    public ResponseEntity<byte[]> getCustomerCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
             @Parameter(description = "Offset for pagination", example = "0")
@@ -93,9 +93,11 @@ public class CustomerRESTController {
                 .map(customerMapper::toDto)
                 .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        customerExportService.exportDto(dtos, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> customerExportService.exportDto(dtos, out));
+                .body(out.toByteArray());
     }
 
     /**
@@ -115,7 +117,7 @@ public class CustomerRESTController {
     )
     @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getCustomer(
+    public ResponseEntity<byte[]> getCustomer(
             @Parameter(description = "Unique identifier of the Customer", required = true)
             @PathVariable UUID customerId) {
 
@@ -123,9 +125,11 @@ public class CustomerRESTController {
                 .map(customerMapper::toDto)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Customer not found"));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        customerExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> customerExportService.exportDto(dto, out));
+                .body(out.toByteArray());
     }
 
     /**

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ElectricPowerQualitySummaryRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ElectricPowerQualitySummaryRESTController.java
@@ -39,8 +39,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -86,7 +86,7 @@ public class ElectricPowerQualitySummaryRESTController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getElectricPowerQualitySummaryCollection(
+    public ResponseEntity<byte[]> getElectricPowerQualitySummaryCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
             @Parameter(description = "Offset for pagination", example = "0")
@@ -96,9 +96,11 @@ public class ElectricPowerQualitySummaryRESTController {
                 .map(electricPowerQualitySummaryMapper::toDto)
                 .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        electricPowerQualitySummaryExportService.exportDto(summaries, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> electricPowerQualitySummaryExportService.exportDto(summaries, out));
+                .body(out.toByteArray());
     }
 
     /**
@@ -121,7 +123,7 @@ public class ElectricPowerQualitySummaryRESTController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getElectricPowerQualitySummary(
+    public ResponseEntity<byte[]> getElectricPowerQualitySummary(
             @Parameter(description = "Unique identifier of the ElectricPowerQualitySummary", required = true)
             @PathVariable UUID electricPowerQualitySummaryId) {
 
@@ -129,9 +131,11 @@ public class ElectricPowerQualitySummaryRESTController {
                 .map(electricPowerQualitySummaryMapper::toDto)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ElectricPowerQualitySummary not found for id: " + electricPowerQualitySummaryId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        electricPowerQualitySummaryExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> electricPowerQualitySummaryExportService.exportDto(dto, out));
+                .body(out.toByteArray());
     }
 
     /**
@@ -152,7 +156,7 @@ public class ElectricPowerQualitySummaryRESTController {
     @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getSubscriptionElectricPowerQualitySummaries(
+    public ResponseEntity<byte[]> getSubscriptionElectricPowerQualitySummaries(
             @Parameter(description = "Unique identifier of the subscription", required = true)
             @PathVariable UUID subscriptionId,
             @Parameter(description = "Unique identifier of the usage point", required = true)
@@ -168,9 +172,11 @@ public class ElectricPowerQualitySummaryRESTController {
                 .map(electricPowerQualitySummaryMapper::toDto)
                 .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        electricPowerQualitySummaryExportService.exportDto(summaries, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> electricPowerQualitySummaryExportService.exportDto(summaries, out));
+                .body(out.toByteArray());
     }
 
     /**
@@ -191,7 +197,7 @@ public class ElectricPowerQualitySummaryRESTController {
     @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getSubscriptionElectricPowerQualitySummary(
+    public ResponseEntity<byte[]> getSubscriptionElectricPowerQualitySummary(
             @Parameter(description = "Unique identifier of the subscription", required = true)
             @PathVariable UUID subscriptionId,
             @Parameter(description = "Unique identifier of the usage point", required = true)
@@ -205,8 +211,10 @@ public class ElectricPowerQualitySummaryRESTController {
                 .map(electricPowerQualitySummaryMapper::toDto)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ElectricPowerQualitySummary not found for id: " + electricPowerQualitySummaryId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        electricPowerQualitySummaryExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> electricPowerQualitySummaryExportService.exportDto(dto, out));
+                .body(out.toByteArray());
     }
 }

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/IntervalBlockRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/IntervalBlockRESTController.java
@@ -39,8 +39,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -79,7 +79,7 @@ public class IntervalBlockRESTController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getIntervalBlockCollection(
+    public ResponseEntity<byte[]> getIntervalBlockCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
             @Parameter(description = "Offset for pagination", example = "0")
@@ -90,11 +90,11 @@ public class IntervalBlockRESTController {
             .map(intervalBlockMapper::toDto)
             .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        intervalBlockExportService.exportDto(dtos, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            intervalBlockExportService.exportDto(dtos, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -116,7 +116,7 @@ public class IntervalBlockRESTController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getIntervalBlock(
+    public ResponseEntity<byte[]> getIntervalBlock(
             @Parameter(description = "Unique identifier of the Interval Block", required = true)
             @PathVariable UUID intervalBlockId,
             Authentication authentication) {
@@ -125,11 +125,11 @@ public class IntervalBlockRESTController {
             .map(intervalBlockMapper::toDto)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Interval Block not found for id: " + intervalBlockId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        intervalBlockExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            intervalBlockExportService.exportDto(dto, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -150,7 +150,7 @@ public class IntervalBlockRESTController {
     @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getSubscriptionIntervalBlocks(
+    public ResponseEntity<byte[]> getSubscriptionIntervalBlocks(
             @Parameter(description = "Unique identifier of the Subscription", required = true)
             @PathVariable UUID subscriptionId,
             @Parameter(description = "Unique identifier of the Usage Point", required = true)
@@ -164,11 +164,11 @@ public class IntervalBlockRESTController {
             .map(intervalBlockMapper::toDto)
             .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        intervalBlockExportService.exportDto(dtos, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            intervalBlockExportService.exportDto(dtos, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -189,7 +189,7 @@ public class IntervalBlockRESTController {
     @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getSubscriptionIntervalBlock(
+    public ResponseEntity<byte[]> getSubscriptionIntervalBlock(
             @Parameter(description = "Unique identifier of the Subscription", required = true)
             @PathVariable UUID subscriptionId,
             @Parameter(description = "Unique identifier of the Usage Point", required = true)
@@ -206,10 +206,10 @@ public class IntervalBlockRESTController {
 
         // TODO: Validate relationship between intervalBlock and meterReading/usagePoint/subscription
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        intervalBlockExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            intervalBlockExportService.exportDto(dto, out);
-        });
+                .body(out.toByteArray());
     }
 }

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/MeterReadingController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/MeterReadingController.java
@@ -39,8 +39,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -84,22 +84,22 @@ public class MeterReadingController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getAllMeterReadings(
+    public ResponseEntity<byte[]> getAllMeterReadings(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
             @Parameter(description = "Offset for pagination", example = "0")
             @RequestParam(defaultValue = "0") int offset,
             Authentication authentication) {
-        
+
         List<MeterReadingDto> meterReadings = meterReadingRepository.findAll(PageRequest.of(offset, limit)).getContent().stream()
             .map(meterReadingMapper::toDto)
             .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        meterReadingExportService.exportDto(meterReadings, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            meterReadingExportService.exportDto(meterReadings, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -121,7 +121,7 @@ public class MeterReadingController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getMeterReading(
+    public ResponseEntity<byte[]> getMeterReading(
             @Parameter(description = "Unique identifier of the Meter Reading", required = true)
             @PathVariable UUID meterReadingId,
             Authentication authentication) {
@@ -130,10 +130,10 @@ public class MeterReadingController {
             .map(meterReadingMapper::toDto)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Meter Reading not found for id: " + meterReadingId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        meterReadingExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            meterReadingExportService.exportDto(dto, out);
-        });
+                .body(out.toByteArray());
     }
 }

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ReadingTypeRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ReadingTypeRESTController.java
@@ -39,8 +39,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -82,7 +82,7 @@ public class ReadingTypeRESTController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getReadingTypeCollection(
+    public ResponseEntity<byte[]> getReadingTypeCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
             @Parameter(description = "Offset for pagination", example = "0")
@@ -93,11 +93,11 @@ public class ReadingTypeRESTController {
             .map(readingTypeMapper::toDto)
             .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        readingTypeExportService.exportDto(readingTypes, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            readingTypeExportService.exportDto(readingTypes, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -119,7 +119,7 @@ public class ReadingTypeRESTController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getReadingType(
+    public ResponseEntity<byte[]> getReadingType(
             @Parameter(description = "Unique identifier of the Reading Type", required = true)
             @PathVariable UUID readingTypeId,
             Authentication authentication) {
@@ -128,10 +128,10 @@ public class ReadingTypeRESTController {
             .map(readingTypeMapper::toDto)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reading Type not found for id: " + readingTypeId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        readingTypeExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            readingTypeExportService.exportDto(dto, out);
-        });
+                .body(out.toByteArray());
     }
 }

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsagePointController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsagePointController.java
@@ -38,8 +38,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -90,18 +90,18 @@ public class UsagePointController {
             "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
             "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     @GetMapping(value = "/UsagePoint", produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<StreamingResponseBody> getAllUsagePoints(@RequestParam(defaultValue = "50") int limit,
-                                                                   @RequestParam(defaultValue = "0") int offset) {
+    public ResponseEntity<byte[]> getAllUsagePoints(@RequestParam(defaultValue = "50") int limit,
+                                                    @RequestParam(defaultValue = "0") int offset) {
 
         List<UsagePointDto> usagePoints =  usagePointRepository.findAll(PageRequest.of(offset, limit)).getContent().stream()
                 .map(usagePointMapper::toDto)
                 .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        usageExportService.exportDto(usagePoints, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            usageExportService.exportDto(usagePoints, out);
-        });
+                .body(out.toByteArray());
     }
 
 //    public ResponseEntity<List<UsagePointDto>> getAllUsagePoints(
@@ -138,18 +138,18 @@ public class UsagePointController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getUsagePoint(
+    public ResponseEntity<byte[]> getUsagePoint(
             @Parameter(description = "Unique identifier of the Usage Point", required = true)
             @PathVariable UUID usagePointId) {
 
         UsagePointDto dto =  usagePointRepository.findById(usagePointId)
                 .map(usagePointMapper::toDto).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usage Point not found for id: " + usagePointId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        usageExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            usageExportService.exportDto(dto, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -170,25 +170,25 @@ public class UsagePointController {
     @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getSubscriptionUsagePoints(
+    public ResponseEntity<byte[]> getSubscriptionUsagePoints(
             @Parameter(description = "Unique identifier of the SubscriptionEntity", required = true)
             @PathVariable UUID subscriptionId,
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
             @Parameter(description = "Offset for pagination", example = "0")
             @RequestParam(defaultValue = "0") int offset) {
-        
+
         // TODO: Implement subscription-based filtering when subscription relationship is available
         // For now, return all usage points with pagination as a temporary solution
         List<UsagePointDto> usagePoints = usagePointRepository.findAll( PageRequest.of(offset, limit)).getContent().stream()
             .map(usagePointMapper::toDto)
             .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        usageExportService.exportDto(usagePoints, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            usageExportService.exportDto(usagePoints, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -209,22 +209,22 @@ public class UsagePointController {
     @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getSubscriptionUsagePoint(
+    public ResponseEntity<byte[]> getSubscriptionUsagePoint(
             @Parameter(description = "Unique identifier of the SubscriptionEntity", required = true)
             @PathVariable UUID subscriptionId,
             @Parameter(description = "Unique identifier of the Usage Point", required = true)
             @PathVariable UUID usagePointId,
             Authentication authentication) {
-        
+
         // TODO: Implement subscription-based validation when subscription relationship is available
         // For now, just return the usage point if it exists
         UsagePointDto dto =  usagePointRepository.findById(usagePointId)
                 .map(usagePointMapper::toDto).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usage Point not found for id: " + usagePointId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        usageExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            usageExportService.exportDto(dto, out);
-        });
+                .body(out.toByteArray());
     }
 }

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsageSummaryRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsageSummaryRESTController.java
@@ -39,8 +39,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -83,7 +83,7 @@ public class UsageSummaryRESTController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getUsageSummaryCollection(
+    public ResponseEntity<byte[]> getUsageSummaryCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
             @Parameter(description = "Offset for pagination", example = "0")
@@ -94,11 +94,11 @@ public class UsageSummaryRESTController {
             .map(usageSummaryMapper::toDto)
             .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        usageSummaryExportService.exportDto(usageSummaries, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            usageSummaryExportService.exportDto(usageSummaries, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -120,7 +120,7 @@ public class UsageSummaryRESTController {
                  "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getUsageSummary(
+    public ResponseEntity<byte[]> getUsageSummary(
             @Parameter(description = "Unique identifier of the Usage Summary", required = true)
             @PathVariable UUID usageSummaryId,
             Authentication authentication) {
@@ -129,11 +129,11 @@ public class UsageSummaryRESTController {
             .map(usageSummaryMapper::toDto)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usage Summary not found for id: " + usageSummaryId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        usageSummaryExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            usageSummaryExportService.exportDto(dto, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -151,7 +151,7 @@ public class UsageSummaryRESTController {
     @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getSubscriptionUsageSummaries(
+    public ResponseEntity<byte[]> getSubscriptionUsageSummaries(
             @Parameter(description = "Unique identifier of the Subscription", required = true)
             @PathVariable UUID subscriptionId,
             @Parameter(description = "Unique identifier of the Usage Point", required = true)
@@ -161,17 +161,17 @@ public class UsageSummaryRESTController {
             @Parameter(description = "Offset for pagination", example = "0")
             @RequestParam(defaultValue = "0") int offset,
             Authentication authentication) {
-        
+
         // TODO: Implement subscription and usage point based filtering when relationships are available
         List<UsageSummaryDto> usageSummaries = usageSummaryRepository.findAll(PageRequest.of(offset, limit)).getContent().stream()
             .map(usageSummaryMapper::toDto)
             .toList();
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        usageSummaryExportService.exportDto(usageSummaries, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            usageSummaryExportService.exportDto(usageSummaries, out);
-        });
+                .body(out.toByteArray());
     }
 
     /**
@@ -189,7 +189,7 @@ public class UsageSummaryRESTController {
     @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
                  "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
-    public ResponseEntity<StreamingResponseBody> getSubscriptionUsageSummary(
+    public ResponseEntity<byte[]> getSubscriptionUsageSummary(
             @Parameter(description = "Unique identifier of the Subscription", required = true)
             @PathVariable UUID subscriptionId,
             @Parameter(description = "Unique identifier of the Usage Point", required = true)
@@ -202,10 +202,10 @@ public class UsageSummaryRESTController {
             .map(usageSummaryMapper::toDto)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usage Summary not found for id: " + usageSummaryId));
 
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        usageSummaryExportService.exportDto(dto, out);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)
-                .body(out -> {
-            usageSummaryExportService.exportDto(dto, out);
-        });
+                .body(out.toByteArray());
     }
 }

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ApplicationInformationRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ApplicationInformationRESTControllerTest.java
@@ -57,12 +57,8 @@ public class ApplicationInformationRESTControllerTest extends AbstractController
             ApplicationInformationEntity entity = new ApplicationInformationEntity();
             when(applicationInformationService.findAll()).thenReturn(List.of(entity));
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ApplicationInformation")
+            mockMvc.perform(get("/espi/1_1/resource/ApplicationInformation")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
 
@@ -75,12 +71,8 @@ public class ApplicationInformationRESTControllerTest extends AbstractController
         void shouldReturn200ForThirdPartyAdmin() throws Exception {
             when(applicationInformationService.findAll()).thenReturn(List.of());
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ApplicationInformation")
+            mockMvc.perform(get("/espi/1_1/resource/ApplicationInformation")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk());
         }
 
@@ -112,12 +104,8 @@ public class ApplicationInformationRESTControllerTest extends AbstractController
             ApplicationInformationEntity entity = new ApplicationInformationEntity();
             when(applicationInformationService.findById(id)).thenReturn(entity);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ApplicationInformation/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/ApplicationInformation/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
 

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerAccountRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerAccountRESTControllerTest.java
@@ -64,12 +64,8 @@ public class CustomerAccountRESTControllerTest extends AbstractControllerMockTes
             when(customerAccountMapper.toDto(any(CustomerAccountEntity.class)))
                     .thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/CustomerAccount")
+            mockMvc.perform(get("/espi/1_1/resource/CustomerAccount")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -105,12 +101,8 @@ public class CustomerAccountRESTControllerTest extends AbstractControllerMockTes
             when(customerAccountRepository.findById(id)).thenReturn(Optional.of(entity));
             when(customerAccountMapper.toDto(entity)).thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/CustomerAccount/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/CustomerAccount/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerRESTControllerTest.java
@@ -28,7 +28,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.List;
 import java.util.Optional;
@@ -65,12 +64,8 @@ public class CustomerRESTControllerTest extends AbstractControllerMockTest {
             when(customerMapper.toDto(any(CustomerEntity.class)))
                     .thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Customer")
+            mockMvc.perform(get("/espi/1_1/resource/Customer")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -106,12 +101,8 @@ public class CustomerRESTControllerTest extends AbstractControllerMockTest {
             when(customerRepository.findById(id)).thenReturn(Optional.of(entity));
             when(customerMapper.toDto(entity)).thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Customer/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/Customer/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ElectricPowerQualitySummaryRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ElectricPowerQualitySummaryRESTControllerTest.java
@@ -36,7 +36,6 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -67,12 +66,8 @@ public class ElectricPowerQualitySummaryRESTControllerTest extends AbstractContr
             when(electricPowerQualitySummaryMapper.toDto(any(ElectricPowerQualitySummaryEntity.class)))
                     .thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ElectricPowerQualitySummary")
+            mockMvc.perform(get("/espi/1_1/resource/ElectricPowerQualitySummary")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -84,12 +79,8 @@ public class ElectricPowerQualitySummaryRESTControllerTest extends AbstractContr
             when(electricPowerQualitySummaryRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ElectricPowerQualitySummary")
+            mockMvc.perform(get("/espi/1_1/resource/ElectricPowerQualitySummary")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -125,12 +116,8 @@ public class ElectricPowerQualitySummaryRESTControllerTest extends AbstractContr
             when(electricPowerQualitySummaryRepository.findById(id)).thenReturn(Optional.of(entity));
             when(electricPowerQualitySummaryMapper.toDto(entity)).thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ElectricPowerQualitySummary/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/ElectricPowerQualitySummary/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -168,12 +155,8 @@ public class ElectricPowerQualitySummaryRESTControllerTest extends AbstractContr
             when(electricPowerQualitySummaryRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/ElectricPowerQualitySummary")
+            mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/ElectricPowerQualitySummary")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -191,12 +174,8 @@ public class ElectricPowerQualitySummaryRESTControllerTest extends AbstractContr
             when(electricPowerQualitySummaryRepository.findById(id)).thenReturn(Optional.of(entity));
             when(electricPowerQualitySummaryMapper.toDto(entity)).thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/ElectricPowerQualitySummary/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/ElectricPowerQualitySummary/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/IntervalBlockRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/IntervalBlockRESTControllerTest.java
@@ -28,7 +28,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +35,6 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -66,12 +64,8 @@ public class IntervalBlockRESTControllerTest extends AbstractControllerMockTest 
             when(intervalBlockMapper.toDto(any(IntervalBlockEntity.class)))
                     .thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/IntervalBlock")
+            mockMvc.perform(get("/espi/1_1/resource/IntervalBlock")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -83,12 +77,8 @@ public class IntervalBlockRESTControllerTest extends AbstractControllerMockTest 
             when(intervalBlockRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/IntervalBlock")
+            mockMvc.perform(get("/espi/1_1/resource/IntervalBlock")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -124,12 +114,8 @@ public class IntervalBlockRESTControllerTest extends AbstractControllerMockTest 
             when(intervalBlockRepository.findById(id)).thenReturn(Optional.of(entity));
             when(intervalBlockMapper.toDto(entity)).thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/IntervalBlock/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/IntervalBlock/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -165,12 +151,8 @@ public class IntervalBlockRESTControllerTest extends AbstractControllerMockTest 
             when(intervalBlockMapper.toDto(any(IntervalBlockEntity.class)))
                     .thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/MeterReading/" + mrId + "/IntervalBlock")
+            mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/MeterReading/" + mrId + "/IntervalBlock")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -205,12 +187,8 @@ public class IntervalBlockRESTControllerTest extends AbstractControllerMockTest 
             when(intervalBlockRepository.findById(ibId)).thenReturn(Optional.of(entity));
             when(intervalBlockMapper.toDto(entity)).thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/MeterReading/" + mrId + "/IntervalBlock/" + ibId)
+            mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/MeterReading/" + mrId + "/IntervalBlock/" + ibId)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/MeterReadingControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/MeterReadingControllerTest.java
@@ -29,7 +29,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.List;
 import java.util.Optional;
@@ -37,7 +36,6 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -68,12 +66,8 @@ public class MeterReadingControllerTest extends AbstractControllerMockTest {
             when(meterReadingMapper.toDto(any(MeterReadingEntity.class)))
                     .thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/MeterReading")
+            mockMvc.perform(get("/espi/1_1/resource/MeterReading")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -85,12 +79,8 @@ public class MeterReadingControllerTest extends AbstractControllerMockTest {
             when(meterReadingRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/MeterReading")
+            mockMvc.perform(get("/espi/1_1/resource/MeterReading")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -126,12 +116,8 @@ public class MeterReadingControllerTest extends AbstractControllerMockTest {
             when(meterReadingRepository.findById(id)).thenReturn(Optional.of(entity));
             when(meterReadingMapper.toDto(entity)).thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/MeterReading/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/MeterReading/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ReadingTypeRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ReadingTypeRESTControllerTest.java
@@ -36,7 +36,6 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -67,12 +66,8 @@ public class ReadingTypeRESTControllerTest extends AbstractControllerMockTest {
             when(readingTypeMapper.toDto(any(ReadingTypeEntity.class)))
                     .thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ReadingType")
+            mockMvc.perform(get("/espi/1_1/resource/ReadingType")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -84,12 +79,8 @@ public class ReadingTypeRESTControllerTest extends AbstractControllerMockTest {
             when(readingTypeRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ReadingType")
+            mockMvc.perform(get("/espi/1_1/resource/ReadingType")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -125,12 +116,8 @@ public class ReadingTypeRESTControllerTest extends AbstractControllerMockTest {
             when(readingTypeRepository.findById(id)).thenReturn(Optional.of(entity));
             when(readingTypeMapper.toDto(entity)).thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/ReadingType/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/ReadingType/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsagePointControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsagePointControllerTest.java
@@ -30,7 +30,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,7 +37,6 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -76,12 +74,8 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
             when(usagePointMapper.toDto(any(UsagePointEntity.class)))
                     .thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/UsagePoint")
+            mockMvc.perform(get("/espi/1_1/resource/UsagePoint")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -93,12 +87,8 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
             when(usagePointRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/UsagePoint")
+            mockMvc.perform(get("/espi/1_1/resource/UsagePoint")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -134,12 +124,8 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
             when(usagePointRepository.findById(id)).thenReturn(Optional.of(entity));
             when(usagePointMapper.toDto(entity)).thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/UsagePoint/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/UsagePoint/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -180,12 +166,8 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
             when(usagePointRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Subscription/" + UUID.randomUUID() + "/UsagePoint")
+            mockMvc.perform(get("/espi/1_1/resource/Subscription/" + UUID.randomUUID() + "/UsagePoint")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -222,12 +204,8 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
             when(usagePointRepository.findById(upId)).thenReturn(Optional.of(entity));
             when(usagePointMapper.toDto(entity)).thenReturn(dto);
 
-            MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId)
+            mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsageSummaryRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsageSummaryRESTControllerTest.java
@@ -36,7 +36,6 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -66,12 +65,8 @@ public class UsageSummaryRESTControllerTest extends AbstractControllerMockTest {
             when(usageSummaryMapper.toDto(any(UsageSummaryEntity.class)))
                     .thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/UsageSummary")
+            mockMvc.perform(get("/espi/1_1/resource/UsageSummary")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -83,12 +78,8 @@ public class UsageSummaryRESTControllerTest extends AbstractControllerMockTest {
             when(usageSummaryRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/UsageSummary")
+            mockMvc.perform(get("/espi/1_1/resource/UsageSummary")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -109,12 +100,8 @@ public class UsageSummaryRESTControllerTest extends AbstractControllerMockTest {
             when(usageSummaryRepository.findById(id)).thenReturn(Optional.of(entity));
             when(usageSummaryMapper.toDto(entity)).thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/UsageSummary/" + id)
+            mockMvc.perform(get("/espi/1_1/resource/UsageSummary/" + id)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
         }
@@ -145,12 +132,8 @@ public class UsageSummaryRESTControllerTest extends AbstractControllerMockTest {
             when(usageSummaryRepository.findAll(any(Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of()));
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/UsageSummary")
+            mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/UsageSummary")
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk());
         }
 
@@ -167,12 +150,8 @@ public class UsageSummaryRESTControllerTest extends AbstractControllerMockTest {
             when(usageSummaryRepository.findById(usId)).thenReturn(Optional.of(entity));
             when(usageSummaryMapper.toDto(entity)).thenReturn(dto);
 
-            org.springframework.test.web.servlet.MvcResult result = mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/UsageSummary/" + usId)
+            mockMvc.perform(get("/espi/1_1/resource/Subscription/" + subId + "/UsagePoint/" + upId + "/UsageSummary/" + usId)
                             .accept(MediaType.APPLICATION_XML))
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk());
         }
     }


### PR DESCRIPTION
## Summary

Phase 1 of the [#119 remediation plan](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/119). Replaces `ResponseEntity<StreamingResponseBody>` with `ResponseEntity<byte[]>` across the 9 REST controllers added by #116 (26 endpoints total), and drops the corresponding async-dispatch plumbing from 30 MockMvc test methods.

**Net diff:** 18 files, +155 / -277 lines.

## Why

CI flake surfaced by #118: `MeterReadingControllerTest.shouldReturn200WhenExists` raises `java.util.ConcurrentModificationException` on an unpredictable subset of runs.

Stack trace shows the worker thread from `StreamingResponseBody` mutating `MockHttpServletResponse`'s `LinkedCaseInsensitiveMap` (via Spring Security's `OnCommittedResponseWrapper` → `HeaderWriterFilter.writeHeaders` → `setHeader` for `X-XSS-Protection`) while the main test thread is reading the same headers map for assertions.

The existing `StreamingResponseBody` was **fake streaming** anyway — JAXB marshals the whole payload to a complete `byte[]` before the worker thread starts, so no actual streaming benefit is lost. ESPI Sandbox response sizes don't warrant streaming. Real-streaming candidates (`/Subscription/*`, `/Batch/Bulk/*` in production utility implementations) need StAX `XMLStreamWriter` + a JPA cursor; that's a future Phase 3 item, deliberately not addressed here.

## Controllers updated

`ApplicationInformationRESTController`, `CustomerAccountRESTController`, `CustomerRESTController`, `ElectricPowerQualitySummaryRESTController`, `IntervalBlockRESTController`, `MeterReadingController`, `ReadingTypeRESTController`, `UsagePointController`, `UsageSummaryRESTController`.

## Test plan

- [x] `mvn test -pl openespi-datacustodian` run 1 — **90 tests, 0 failures, 0 errors, 1 skipped** (`Tests run: 90, Failures: 0, Errors: 0, Skipped: 1`)
- [x] Run 2 — BUILD SUCCESS in 2:32
- [x] Run 3 — BUILD SUCCESS in 2:18
- [x] `MeterReadingControllerTest.shouldReturn200WhenExists` passes deterministically across all 3 runs
- [x] No `StreamingResponseBody` references remain in `openespi-datacustodian/src/main` (controllers + Javadoc)
- [x] No `asyncDispatch` / `request().asyncStarted()` / `MvcResult` references remain in `openespi-datacustodian/src/test/java/.../web/api/`
- [ ] CI: PR Validation + Build and Test pass on this PR

Refs #119 (Phase 1).