### PR TITLE
docs: broaden Docker prerequisites to cover WSL2 and non-Desktop setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,19 @@ mvn test -pl openespi-common
 ### Integration Tests with TestContainers
 
 **Prerequisites:**
-- Docker Desktop installed and running
+- A reachable Docker daemon (any of the following works):
+  - Docker Desktop on Windows (WSL2 backend) or macOS
+  - Docker Engine in WSL2 (without Docker Desktop)
+  - Docker Engine native on Linux
+  - Rancher Desktop or Podman with Docker socket compatibility
 - Minimum 4GB RAM allocated to Docker
-- Ports 3306 (MySQL) and 5432 (PostgreSQL) available
+- TestContainers auto-detects the Docker socket — no project configuration required
+
+> **Note for WSL2 users running Docker Engine without Docker Desktop:** make sure the daemon is running (`sudo systemctl start docker`) and your user is in the `docker` group (`sudo usermod -aG docker $USER`, then re-login). If `dockerd` fails to start, check `/etc/docker/daemon.json` for a `hosts` entry that conflicts with the systemd unit's `-H fd://` flag.
 
 **Quick Start:**
 ```bash
-# Verify Docker is running
+# Verify Docker is reachable (any setup above)
 docker --version && docker ps
 
 # Run all integration tests (H2, MySQL, PostgreSQL)


### PR DESCRIPTION
## Summary
- Replaces the single "Docker Desktop installed and running" line in the README with a list of all supported Docker setups (Docker Desktop, Docker Engine on Linux, Docker in WSL2, Rancher Desktop / Podman with Docker-API compat).
- Adds a short WSL2 troubleshooting note for the `daemon.json` `hosts` vs systemd `-H fd://` conflict that bites pure-WSL Docker installs.

TestContainers already auto-detects whatever Docker daemon is reachable — the project supports all of these setups, the README just needed to say so. No code or test changes.

## Test plan
- [x] README renders correctly on GitHub (markdown only)
- [x] No code paths touched — existing CI suffices

🤖 Generated with [Claude Code](https://claude.com/claude-code)