### PR TITLE
fix(authserver): six pre-existing defects blocking dev-mysql boot

### DIFF
--- a/openespi-authserver/docker/docker-compose.yml
+++ b/openespi-authserver/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       
       # Flyway Configuration
       SPRING_FLYWAY_ENABLED: true
-      SPRING_FLYWAY_LOCATIONS: classpath:db/migration/mysql
+      SPRING_FLYWAY_LOCATIONS: classpath:db/vendor/mysql
       SPRING_FLYWAY_BASELINE_ON_MIGRATE: true
       
       # Security Configuration

--- a/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/config/AuthorizationServerConfig.java
+++ b/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/config/AuthorizationServerConfig.java
@@ -136,11 +136,14 @@ public class AuthorizationServerConfig {
                                 new MediaTypeRequestMatcher(MediaType.TEXT_HTML)
                         )
                 )
-                // Accept access tokens for User Info and/or Client Registration
+                // Accept access tokens for User Info and/or Client Registration.
+                // OIDC auto-configures JWT validation for self-protected endpoints
+                // (id_token signing requires JWT). Outbound tokens to ESPI clients
+                // remain opaque via accessTokenFormat(REFERENCE) on each RegisteredClient.
+                // Cannot configure both .jwt() and .opaqueToken() on the same chain
+                // in Spring Security 7.x.
                 .oauth2ResourceServer(resourceServer -> resourceServer
-                        .opaqueToken(Customizer.withDefaults())
-
-                        //.jwt(Customizer.withDefaults())
+                        .jwt(Customizer.withDefaults())
                 )
                 // HTTPS Channel Security for Production
                 //should be able to use property server.ssl.enabled=true

--- a/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/config/HttpsEnforcementConfig.java
+++ b/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/config/HttpsEnforcementConfig.java
@@ -98,7 +98,12 @@ public class HttpsEnforcementConfig {
      * 
      * Enforces TLS 1.3 for all requests in production environment (NAESB ESPI 4.0)
      */
-    @Bean
+    // DISABLED: this chain's securityMatcher("/**") at @Order(0) preempts the
+    // authorization-server filter chain at @Order(1), causing every OAuth2 endpoint
+    // to 404. Headers should be injected via a HeaderWriter or Filter, not via a
+    // SecurityFilterChain that monopolizes /**. AuthorizationServerConfig's own
+    // chain (@Order(1)) already configures equivalent security headers.
+    // @Bean
     @Profile("prod")
     @Order(0)
     public SecurityFilterChain httpsEnforcementFilterChain(HttpSecurity http) throws Exception {
@@ -151,7 +156,9 @@ public class HttpsEnforcementConfig {
      * 
      * Allows HTTP for development while still providing security headers
      */
-    @Bean
+    // DISABLED: same reason as httpsEnforcementFilterChain above — securityMatcher("/**")
+    // at @Order(0) blocks the auth-server endpoints.
+    // @Bean
     @Profile({"dev", "dev-mysql", "dev-postgresql", "local"})
     @Order(0)
     public SecurityFilterChain developmentSecurityFilterChain(HttpSecurity http) throws Exception {

--- a/openespi-authserver/src/main/resources/application-dev-mysql.yml
+++ b/openespi-authserver/src/main/resources/application-dev-mysql.yml
@@ -14,7 +14,11 @@ spring:
       minimum-idle: 5
       idle-timeout: 300000
       max-lifetime: 1200000
-      auto-commit: false
+      # auto-commit must be true: JdbcRegisteredClientRepository.save() and other
+      # repository methods do not declare @Transactional, so without auto-commit
+      # their INSERTs are never committed and silently roll back when the
+      # connection returns to the pool. Architectural cleanup tracked separately.
+      auto-commit: true
   
   # JPA/Hibernate Configuration for MySQL
   jpa:
@@ -36,11 +40,14 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-    locations: classpath:db/migration/mysql
+    locations: classpath:db/vendor/mysql
     schemas: oauth2_authserver
     user: ${spring.datasource.username}
     password: ${spring.datasource.password}
     url: ${spring.datasource.url}
+    # Skip V3+ pending ESPI 4.0 XSD-aligned schema repair (see issue #123).
+    # V1+V2 provide enough for OAuth2 grant + introspection; V3 onwards is seed/demo data.
+    target: "2.0.0"
 
 # Development Logging
 logging:

--- a/openespi-authserver/src/main/resources/application-dev-postgresql.yml
+++ b/openespi-authserver/src/main/resources/application-dev-postgresql.yml
@@ -38,7 +38,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-    locations: classpath:db/migration/postgresql
+    locations: classpath:db/vendor/postgresql
     schemas: public
   
   # Security Configuration

--- a/openespi-authserver/src/main/resources/application-local.yml
+++ b/openespi-authserver/src/main/resources/application-local.yml
@@ -37,7 +37,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-    locations: classpath:db/migration/h2
+    locations: classpath:db/vendor/h2
     schemas: oauth2_authserver
 
 # Local Development Logging

--- a/openespi-authserver/src/main/resources/application-prod.yml
+++ b/openespi-authserver/src/main/resources/application-prod.yml
@@ -89,7 +89,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-    locations: classpath:db/migration/mysql
+    locations: classpath:db/vendor/mysql
     schemas: oauth2_authserver
     validate-on-migrate: true
     clean-disabled: true

--- a/openespi-authserver/src/main/resources/application.yml
+++ b/openespi-authserver/src/main/resources/application.yml
@@ -50,7 +50,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-    locations: classpath:db/migration,classpath:db/vendor/h2
+    locations: classpath:db/vendor/h2
     #schemas: oauth2_authserver
   jackson:
     default-property-inclusion: non_null

--- a/openespi-authserver/src/main/resources/db/vendor/mysql/V1_0_0__create_oauth2_schema.sql
+++ b/openespi-authserver/src/main/resources/db/vendor/mysql/V1_0_0__create_oauth2_schema.sql
@@ -64,7 +64,8 @@ CREATE TABLE oauth2_registered_client (
     scopes varchar(1000) NOT NULL,
     client_settings varchar(2000) NOT NULL,
     token_settings varchar(2000) NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_oauth2_registered_client_client_id (client_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ESPI Application Information mapping
@@ -109,5 +110,4 @@ CREATE INDEX idx_oauth2_authorization_client_principal ON oauth2_authorization (
 CREATE INDEX idx_oauth2_authorization_code ON oauth2_authorization (authorization_code_value(255));
 CREATE INDEX idx_oauth2_authorization_access_token ON oauth2_authorization (access_token_value(255));
 CREATE INDEX idx_oauth2_authorization_refresh_token ON oauth2_authorization (refresh_token_value(255));
-CREATE INDEX idx_oauth2_registered_client_id ON oauth2_registered_client (client_id);
 CREATE INDEX idx_espi_application_client_id ON espi_application_info (client_id);


### PR DESCRIPTION
## Summary

Fixes six independent pre-existing defects that prevented `openespi-authserver` from booting clean against MySQL. Discovered during Phase 2.0 auth-server bring-up ([#122](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/122)). Static audit had been optimistic; runtime exposed the full picture.

This PR's scope is narrowly **"boot reaches `Started AuthorizationServerApplication` state"** — it deliberately does NOT include the patches needed to actually mint and introspect tokens. Those are tracked as separate issues so each fix can be reviewed on its own merits.

## What's in this PR

| # | Defect | File | Patch |
|---|---|---|---|
| 1 | MySQL V1 FK to `oauth2_registered_client.client_id` fails — referenced column has no unique constraint | `db/vendor/mysql/V1_0_0__create_oauth2_schema.sql` | Added `UNIQUE KEY uk_oauth2_registered_client_client_id`; removed redundant non-unique index |
| 2 | Flyway YAMLs point at `db/migration/{vendor}/` but source files live at `db/vendor/{vendor}/`. Boot only "worked" before due to stale `target/classes/db/migration/` artifacts. | 5 YAMLs + `docker-compose.yml` | All 6 references updated to `classpath:db/vendor/...` |
| 3 | V3+ migrations reference columns not in MySQL V1 (`client_description`, `contact_name`, etc.). Tracked as **[#123](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/123)**. | `application-dev-mysql.yml` | Workaround: `spring.flyway.target: "2.0.0"` (V1+V2 are sufficient for OAuth2 grant + introspection; V3+ is seed/demo data) |
| 4 | `oauth2ResourceServer().opaqueToken(...)` declared on a chain that also has OIDC (which auto-wires JWT) → Spring Security 7.x fails fast | `AuthorizationServerConfig.java` | Switched to `.jwt(Customizer.withDefaults())`. **Outbound opaque tokens to ESPI clients are unaffected** — controlled per-`RegisteredClient` via `accessTokenFormat(OAuth2TokenFormat.REFERENCE)`. |
| 5 | Two `SecurityFilterChain @Order(0)` beans with `securityMatcher("/**")` preempted the auth-server's `@Order(1)` chain → every OAuth2 endpoint 404 | `HttpsEnforcementConfig.java` | Disabled both `@Bean` annotations. Auth-server's own chain already configures equivalent headers. Re-introducing dev-friendly cache-control headers via a proper `HeaderWriter`/`Filter` is a follow-up cleanup. |
| 6 | HikariCP `auto-commit: false` + repository `save()` lacking `@Transactional` → seed INSERTs silently roll back when the connection returns to the pool | `application-dev-mysql.yml` | Set `auto-commit: true`. Proper architectural fix (`@Transactional` throughout repository) deferred. |

**Diff: 9 files changed, +32 / -15 lines.**

## What works after this PR

- `mvn clean install -pl openespi-authserver -am` succeeds
- `mvn -pl openespi-authserver -Dspring-boot.run.profiles=dev-mysql spring-boot:run` reaches `Started AuthorizationServerApplication in ~35-42 seconds`
- Flyway V1+V2 apply cleanly to a fresh MySQL 8.4
- Three default ESPI clients persist correctly: `data_custodian_admin`, `third_party`, `third_party_admin`
- Discovery endpoints return 200:
  - `/.well-known/oauth-authorization-server`
  - `/.well-known/openid-configuration`
  - `/oauth2/jwks`
  - `/login`

## What does NOT work yet (deliberately out of scope, tracked separately)

- `POST /oauth2/token` returns 401 — resource-server bearer filter preempts token endpoint. Filed as **[#124](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/124)** (filter chain needs canonical `OAuth2AuthorizationServerConfiguration.applyDefaultSecurity()` pattern + second `@Order(2)` chain).
- `JdbcRegisteredClientRepository.findAll()` returns empty even when rows persisted. Boot logs `Default ESPI Clients: 0` despite 3 actual rows. Defect #8 from the [#122 audit](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/122#issuecomment-4531323893); not yet investigated.
- V3-V6 Flyway migrations skipped via `target=2.0.0` pending [#123](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/123) schema repair.

## Why six patches in one PR

Each patch independently blocks the next defect from being discovered. Patches #1-#6 form a single dependency chain — none can be tested in isolation against MySQL because each one is masking the next. Splitting them would create six PRs that fail their own CI individually. Reviewing them together with the audit context ([#122 comment](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/122#issuecomment-4531323893)) is the cleanest path.

## Test plan

- [x] Manual: `mvn clean install -pl openespi-authserver` succeeds
- [x] Manual: with fresh MySQL container, `mvn spring-boot:run -Dspring-boot.run.profiles=dev-mysql` reaches `Started AuthorizationServerApplication`
- [x] Manual: `curl http://localhost:9999/.well-known/oauth-authorization-server` returns 200 with correct token/introspection URLs
- [x] Manual: DB SELECT confirms 3 seeded clients persisted (when paired with autocommit fix)
- [ ] CI: full test suite passes on this branch (will verify in CI)
- [ ] Automated integration test for boot-to-Started exists — **deferred to [#124](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/124)** PR (where the token-mint flow can also be exercised end-to-end)

## Related

- Closes nothing; advances [#122](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/122)
- Blocks/blocked-by: [#123](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/123) (schema repair), [#124](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/124) (filter chain)
- Full session findings: [#122 comment](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/122#issuecomment-4531323893)

🤖 Generated with [Claude Code](https://claude.com/claude-code)