### PR TITLE
fix(authserver): sync prod + H2 profile defects discovered after PR #125

### DIFF
--- a/openespi-authserver/src/main/resources/application-prod.yml
+++ b/openespi-authserver/src/main/resources/application-prod.yml
@@ -93,6 +93,10 @@ spring:
     schemas: oauth2_authserver
     validate-on-migrate: true
     clean-disabled: true
+    # Skip V3+ pending ESPI 4.0 XSD-aligned schema repair (see issue #123).
+    # V1+V2 provide enough for OAuth2 grant + introspection; V3 onwards is
+    # seed/demo data that references columns missing from MySQL V1.
+    target: "2.0.0"
 
 # Logging Configuration - Production Levels
 logging:

--- a/openespi-authserver/src/main/resources/db/vendor/h2/V1_0_0__create_oauth2_schema.sql
+++ b/openespi-authserver/src/main/resources/db/vendor/h2/V1_0_0__create_oauth2_schema.sql
@@ -64,7 +64,8 @@ CREATE TABLE oauth2_registered_client (
     scopes varchar(1000) NOT NULL,
     client_settings varchar(2000) NOT NULL,
     token_settings varchar(2000) NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    CONSTRAINT uk_oauth2_registered_client_client_id UNIQUE (client_id)
 );
 
 -- ESPI Application Information mapping
@@ -105,7 +106,6 @@ CREATE TABLE espi_application_info (
 
 -- Create indexes for performance
 CREATE INDEX idx_oauth2_authorization_client_principal ON oauth2_authorization (registered_client_id, principal_name);
-CREATE INDEX idx_oauth2_registered_client_id ON oauth2_registered_client (client_id);
 CREATE INDEX idx_espi_application_client_id ON espi_application_info (client_id);
 
 -- Insert sample data for local development


### PR DESCRIPTION
## Summary

Follow-up to [#125](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/pull/125). Propagates two patches from that PR to the profiles where the same defects exist but weren't directly observed during the dev-mysql boot session. Cross-profile audit summarized at [#122 comment](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/122#issuecomment-4531323893).

## Changes

### 1. `application-prod.yml` — add `flyway.target: "2.0.0"` workaround for [#123](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/123)

Prod uses MySQL vendor migrations (`classpath:db/vendor/mysql`). A first deploy against a clean prod DB would die at V3 with `Unknown column 'client_description'` — identical to the dev-mysql failure that #125 patched. Without this fix, prod is a latent landmine waiting for someone to migrate a fresh database.

This is a **temporary workaround** — removed once #123 (ESPI 4.0 XSD-aligned schema repair) lands.

### 2. H2 V1 — add `UNIQUE` constraint on `oauth2_registered_client.client_id`

H2 V1 schema had only `PRIMARY KEY (id)` on `oauth2_registered_client` and a non-unique `CREATE INDEX` on `client_id`, while MySQL V1 (after #125) and PostgreSQL V1 (already correct) both enforce uniqueness on that column. `client_id` is unique by OAuth2 semantics; the inconsistency invites future bugs (e.g., if anyone adds an FK referencing this column in H2 later, they'd hit the same MySQL bug #125 fixed).

Not blocking H2 boot today — H2's `espi_application_info` table doesn't declare an FK against `oauth2_registered_client.client_id`, so the absence of UNIQUE isn't a CREATE TABLE error. This change closes the consistency gap. Also removed the now-redundant non-unique `CREATE INDEX`, mirroring the MySQL cleanup from #125.

## Audited and **no change needed**

| Item | Verdict |
|---|---|
| Patch #6 from #125 (HikariCP `auto-commit: true`) | `dev-postgresql`, `local`, `prod`, `docker-compose` all rely on the HikariCP default (true). The `dev-mysql` `auto-commit: false` was an **outlier bug**, not a shared default. |
| PostgreSQL V3 INSERT drift | PostgreSQL V1 (`db/vendor/postgresql/V1_0_0:79-119`) already declares `client_description`, `contact_*`, `scope`, `grant_types`, `response_types` — different drift pattern from MySQL. `dev-postgresql` doesn't need `target=2.0.0` at this time. V4-V6 drift is part of #123's audit scope. |
| Patches #2 (Flyway location), #4 (filter chain), #5 (HttpsEnforcement chains) | Already cross-profile or code-level — #125 covered them. |

## Diff

```
2 files changed, 6 insertions(+), 2 deletions(-)
 openespi-authserver/src/main/resources/application-prod.yml
 openespi-authserver/src/main/resources/db/vendor/h2/V1_0_0__create_oauth2_schema.sql
```

## Test plan

- [x] Manual: `git diff` reviewed for both files
- [ ] CI: full suite passes (will verify)
- [ ] H2 boot: not exercised in this PR (`local` profile boot is its own work item); the H2 change is architectural-consistency only
- [ ] Prod boot: not exercised in this PR; the change is a forward-looking landmine fix

## Related

- [#122](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/122) Phase 2.0 auth-server bring-up
- [#123](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/issues/123) ESPI 4.0 XSD-aligned schema repair (removes the `target: "2.0.0"` workaround when it lands)
- [#125](https://github.com/GreenButtonAlliance/OpenESPI-GreenButton-Java/pull/125) Six pre-existing defects blocking dev-mysql boot (this PR's parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)