### PR TITLE
feat(#122 PR C2b): customer Authorization Screen with per-FB consent

### DIFF
--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/handoff/SignedHandoff.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/handoff/SignedHandoff.java
@@ -124,6 +124,15 @@ public sealed interface SignedHandoff permits SignedHandoff.Outbound, SignedHand
 	 * @param customerResourceUri     absolute URI of the customer/PII resource the customer
 	 *                                approved sharing, or {@code null} if not granted
 	 * @param consent                 {@code "allow"} if the customer granted; {@code "deny"} if not
+	 * @param approvedScope           the effective scope after the customer's checkbox decisions
+	 *                                &mdash; subset of the originally-requested scope. The AS
+	 *                                mints the access token with <em>this</em> scope, not the
+	 *                                original. {@code null} on {@code consent="deny"}.
+	 *                                <p>Additive field introduced in PR C2b. Codec version remains
+	 *                                at 1 because old readers parsing this payload simply see
+	 *                                {@code approvedScope=null}; they had no use for it anyway
+	 *                                because the customer-checkbox UI (and the effective scope)
+	 *                                did not exist when C1 shipped.</p>
 	 */
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	record Return(
@@ -136,7 +145,8 @@ public sealed interface SignedHandoff permits SignedHandoff.Outbound, SignedHand
 			@JsonProperty("sub") String principal,
 			@JsonProperty("up") List<UUID> selectedUsagePointIds,
 			@JsonProperty("cust_uri") String customerResourceUri,
-			@JsonProperty("consent") String consent
+			@JsonProperty("consent") String consent,
+			@JsonProperty("approved_scope") String approvedScope
 	) implements SignedHandoff {
 
 		public static final String CONSENT_ALLOW = "allow";
@@ -145,9 +155,9 @@ public sealed interface SignedHandoff permits SignedHandoff.Outbound, SignedHand
 		/** Convenience factory that fills in {@code version} and {@code direction}. */
 		public static Return of(String correlationId, Instant issuedAt, Instant expiresAt, String nonce,
 								String principal, List<UUID> selectedUsagePointIds,
-								String customerResourceUri, String consent) {
+								String customerResourceUri, String consent, String approvedScope) {
 			return new Return(CURRENT_VERSION, DIRECTION_RETURN, correlationId, issuedAt, expiresAt,
-					nonce, principal, selectedUsagePointIds, customerResourceUri, consent);
+					nonce, principal, selectedUsagePointIds, customerResourceUri, consent, approvedScope);
 		}
 	}
 }

--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/scope/FunctionBlock.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/scope/FunctionBlock.java
@@ -196,4 +196,83 @@ public enum FunctionBlock {
 		FunctionBlock fb = BY_ID.get(id);
 		return fb == null ? Optional.empty() : fb.getServiceKind();
 	}
+
+	// --- Authorization Screen role helpers (PR C2b) -------------------------------------------
+	//
+	// These predicates classify an FB by the consent-UI role it plays:
+	//   - implicit base   : structural prerequisite, never a customer-visible choice (FB 1, 4, 51)
+	//   - commodity       : ServiceKind discriminator, drives commodity sections
+	//   - data-shape mod. : display-only modifier on the energy-data response (e.g. UsageSummary)
+	//   - PII-selectable  : individual consent checkbox in the customer/PII section
+	//
+	// They are computed from {@link #getId()} / {@link #getCategory()} and are non-localized
+	// behavior. The customer-facing strings live in {@code messages.properties} (Spring i18n).
+
+	/**
+	 * Implicit-base FBs are structural prerequisites that must accompany any meaningful grant:
+	 * <ul>
+	 *   <li>{@code FB 1} &mdash; Common (Energy Usage): UsagePoint + ServiceCategory +
+	 *       LocalTimeParameters in the energy feed.</li>
+	 *   <li>{@code FB 4} &mdash; Interval Metering: MeterReading / ReadingType registry.</li>
+	 *   <li>{@code FB 51} &mdash; Common (Retail Customer): cust:LocalTimeParameters for the
+	 *       customer feed.</li>
+	 * </ul>
+	 * The Authorization Screen treats these as display-only context (a footer note), never as
+	 * customer-selectable checkboxes.
+	 */
+	public boolean isImplicitBase() {
+		return id == 1 || id == 4 || id == 51;
+	}
+
+	/** @see #isImplicitBase() */
+	public static boolean isImplicitBase(int id) {
+		return id == 1 || id == 4 || id == 51;
+	}
+
+	/**
+	 * Commodity FBs (FB 5&ndash;11, 29) name what kind of meter the data comes from
+	 * (electricity / gas / water / temperature) and, within a commodity, the measurement profile
+	 * (e.g. interval / demand / net / reverse / register). The Authorization Screen groups
+	 * customer usage points under their {@link ServiceKind}-matching commodity section and
+	 * displays the requested profiles as a sub-line; the customer toggles individual usage
+	 * points but not the profile FBs themselves.
+	 */
+	public boolean isCommodityProfile() {
+		return category == FunctionBlockCategory.COMMODITY;
+	}
+
+	/** @see #isCommodityProfile() */
+	public static boolean isCommodityProfile(int id) {
+		return byId(id).map(FunctionBlock::isCommodityProfile).orElse(false);
+	}
+
+	/**
+	 * Data-shape modifiers (FB 12, 15, 16, 17, 27, 28) shape <em>which response sections</em>
+	 * are emitted by the energy endpoint (UsageSummary, ElectricPowerQualitySummary, etc.) but
+	 * are orthogonal to the commodity. The Authorization Screen shows them as a display-only
+	 * "you will receive" sub-line under each commodity section; the customer cannot toggle
+	 * individual modifiers.
+	 */
+	public boolean isDataShapeModifier() {
+		return category == FunctionBlockCategory.ENERGY_DATA_SHAPE;
+	}
+
+	/** @see #isDataShapeModifier() */
+	public static boolean isDataShapeModifier(int id) {
+		return byId(id).map(FunctionBlock::isDataShapeModifier).orElse(false);
+	}
+
+	/**
+	 * Customer/PII FBs (FB 54&ndash;62) each carry a distinct {@code customer.xsd} resource
+	 * family. The Authorization Screen renders one individually-toggleable consent checkbox per
+	 * PII FB present in the requested scope, default-unchecked (explicit opt-in per FB).
+	 */
+	public boolean isPiiSelectable() {
+		return category == FunctionBlockCategory.CUSTOMER_PII;
+	}
+
+	/** @see #isPiiSelectable() */
+	public static boolean isPiiSelectable(int id) {
+		return byId(id).map(FunctionBlock::isPiiSelectable).orElse(false);
+	}
 }

--- a/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/handoff/SignedHandoffCodecTest.java
+++ b/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/handoff/SignedHandoffCodecTest.java
@@ -68,7 +68,8 @@ class SignedHandoffCodecTest {
 				"customer-42",
 				List.of(UUID.randomUUID(), UUID.randomUUID()),
 				"https://dc.example.com/.../Customer/abc",
-				SignedHandoff.Return.CONSENT_ALLOW);
+				SignedHandoff.Return.CONSENT_ALLOW,
+				"FB=4_5_15;IntervalDuration=3600");
 
 		String token = codec.encode(original);
 		SignedHandoff.Return decoded = codec.decodeReturn(token);
@@ -86,7 +87,8 @@ class SignedHandoffCodecTest {
 				"customer-42",
 				List.of(),
 				null,
-				SignedHandoff.Return.CONSENT_DENY);
+				SignedHandoff.Return.CONSENT_DENY,
+				null);
 
 		String token = codec.encode(original);
 		SignedHandoff.Return decoded = codec.decodeReturn(token);

--- a/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/scope/FunctionBlockRoleHelpersTest.java
+++ b/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/scope/FunctionBlockRoleHelpersTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Green Button Alliance, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.greenbuttonalliance.espi.common.scope;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the Authorization Screen role-classifier predicates added in PR C2b. Each FB has
+ * exactly one screen role (implicit base / commodity profile / data-shape modifier / PII-selectable
+ * / none-of-the-above) and the predicates are checked for correctness against representative ids.
+ */
+class FunctionBlockRoleHelpersTest {
+
+	@ParameterizedTest
+	@ValueSource(ints = {1, 4, 51})
+	void implicitBase_ids_are_recognized(int fbId) {
+		assertThat(FunctionBlock.isImplicitBase(fbId)).isTrue();
+		assertThat(FunctionBlock.byId(fbId)).hasValueSatisfying(fb -> {
+			assertThat(fb.isImplicitBase()).isTrue();
+			assertThat(fb.isCommodityProfile()).isFalse();
+			assertThat(fb.isDataShapeModifier()).isFalse();
+			assertThat(fb.isPiiSelectable()).isFalse();
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {5, 6, 7, 8, 9, 10, 11, 29})
+	void commodityProfile_ids_are_recognized(int fbId) {
+		assertThat(FunctionBlock.isCommodityProfile(fbId)).isTrue();
+		assertThat(FunctionBlock.byId(fbId)).hasValueSatisfying(fb -> {
+			assertThat(fb.isCommodityProfile()).isTrue();
+			assertThat(fb.isImplicitBase()).isFalse();
+			assertThat(fb.isDataShapeModifier()).isFalse();
+			assertThat(fb.isPiiSelectable()).isFalse();
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {12, 15, 16, 17, 27, 28})
+	void dataShapeModifier_ids_are_recognized(int fbId) {
+		assertThat(FunctionBlock.isDataShapeModifier(fbId)).isTrue();
+		assertThat(FunctionBlock.byId(fbId)).hasValueSatisfying(fb -> {
+			assertThat(fb.isDataShapeModifier()).isTrue();
+			assertThat(fb.isImplicitBase()).isFalse();
+			assertThat(fb.isCommodityProfile()).isFalse();
+			assertThat(fb.isPiiSelectable()).isFalse();
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {54, 55, 56, 57, 58, 59, 60, 61, 62})
+	void piiSelectable_ids_are_recognized(int fbId) {
+		assertThat(FunctionBlock.isPiiSelectable(fbId)).isTrue();
+		assertThat(FunctionBlock.byId(fbId)).hasValueSatisfying(fb -> {
+			assertThat(fb.isPiiSelectable()).isTrue();
+			assertThat(fb.isImplicitBase()).isFalse();
+			assertThat(fb.isCommodityProfile()).isFalse();
+			assertThat(fb.isDataShapeModifier()).isFalse();
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {2, 3, 13, 30, 31, 53, 63, 14 /* deprecated */, 999 /* unknown */})
+	void other_ids_are_none_of_the_screen_roles(int fbId) {
+		assertThat(FunctionBlock.isImplicitBase(fbId)).isFalse();
+		assertThat(FunctionBlock.isCommodityProfile(fbId)).isFalse();
+		assertThat(FunctionBlock.isDataShapeModifier(fbId)).isFalse();
+		assertThat(FunctionBlock.isPiiSelectable(fbId)).isFalse();
+	}
+}

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenController.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025 Green Button Alliance, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.greenbuttonalliance.espi.datacustodian.web.authorize;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.greenbuttonalliance.espi.common.domain.usage.ApplicationInformationEntity;
+import org.greenbuttonalliance.espi.common.domain.usage.RetailCustomerEntity;
+import org.greenbuttonalliance.espi.common.domain.usage.UsagePointEntity;
+import org.greenbuttonalliance.espi.common.handoff.HandoffNonceService;
+import org.greenbuttonalliance.espi.common.handoff.InvalidHandoffException;
+import org.greenbuttonalliance.espi.common.handoff.SignedHandoff;
+import org.greenbuttonalliance.espi.common.handoff.SignedHandoffCodec;
+import org.greenbuttonalliance.espi.common.repositories.usage.RetailCustomerRepository;
+import org.greenbuttonalliance.espi.common.repositories.usage.UsagePointRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+
+/**
+ * The customer-facing OAuth2 Authorization Screen.
+ *
+ * <p>Reached after the customer has authenticated through {@link
+ * org.greenbuttonalliance.espi.datacustodian.web.LoginController} (PR C2a). The flow:</p>
+ *
+ * <ol>
+ *   <li>AS redirects user-agent here with {@code ?handoff=<signed.payload>} (PR C1 codec).</li>
+ *   <li>GET decodes + verifies the handoff, consumes the nonce, looks up
+ *       {@link ApplicationInformationEntity}, validates the granted scope is a subset of the
+ *       third party's registered scopes, builds the view model, renders.</li>
+ *   <li>Customer makes selections, POSTs to this controller.</li>
+ *   <li>POST re-verifies the handoff (the form posted it back), computes the effective approved
+ *       scope from the customer's checkbox decisions, builds a {@link SignedHandoff.Return},
+ *       redirects user-agent to the AS's {@code return_url} with the signed return token.</li>
+ * </ol>
+ *
+ * <p>Mounted on the customer-login {@code SecurityFilterChain} (PR C2a). Any
+ * {@link InvalidHandoffException} surfaces as HTTP 400 with the uniform error page &mdash; the
+ * exception handler in this class logs the specific sub-cause for security audit but reveals
+ * nothing to the user-agent (security principle: don't tell an attacker which check failed).</p>
+ */
+@Slf4j
+@Controller
+@RequestMapping("/oauth/authorize-screen")
+@RequiredArgsConstructor
+public class AuthorizeScreenController {
+
+	private static final Duration RETURN_HANDOFF_TTL = Duration.ofMinutes(5);
+
+	private final SignedHandoffCodec codec;
+	private final HandoffNonceService nonceService;
+	private final AuthorizeScreenService authorizeScreenService;
+	private final RetailCustomerRepository retailCustomerRepository;
+	private final UsagePointRepository usagePointRepository;
+	private final Clock clock = Clock.systemUTC();
+
+	@GetMapping
+	public String show(@RequestParam("handoff") String handoffToken,
+					   @AuthenticationPrincipal UserDetails principal,
+					   Locale locale,
+					   Model model) {
+		SignedHandoff.Outbound outbound = decodeAndConsume(handoffToken);
+		ApplicationInformationEntity application = authorizeScreenService.validateClientAndScope(
+				outbound.clientId(), outbound.grantedScope());
+
+		RetailCustomerEntity customer = customerOrReject(principal);
+
+		AuthorizeScreenViewModel viewModel = authorizeScreenService.buildViewModel(
+				application, outbound.grantedScope(), customer.getId(), handoffToken, locale);
+
+		model.addAttribute("viewModel", viewModel);
+		return "authorize-screen";
+	}
+
+	@PostMapping
+	public String submit(@RequestParam("handoff") String handoffToken,
+						 @RequestParam("decision") String decision,
+						 @RequestParam(value = "selected_usage_point_ids", required = false) Set<UUID> selectedUsagePointIds,
+						 @RequestParam(value = "approved_pii_fbs", required = false) Set<Integer> approvedPiiFbs,
+						 @AuthenticationPrincipal UserDetails principal) {
+
+		SignedHandoff.Outbound outbound = decodeAndConsume(handoffToken);
+		ApplicationInformationEntity application = authorizeScreenService.validateClientAndScope(
+				outbound.clientId(), outbound.grantedScope());
+
+		RetailCustomerEntity customer = customerOrReject(principal);
+		boolean isAllow = "allow".equalsIgnoreCase(decision);
+
+		Set<UUID> selectedUps = selectedUsagePointIds != null && isAllow
+				? new HashSet<>(selectedUsagePointIds) : Set.of();
+		Set<Integer> approvedPii = approvedPiiFbs != null && isAllow
+				? new TreeSet<>(approvedPiiFbs) : Set.of();
+
+		List<UsagePointEntity> customerUsagePoints =
+				usagePointRepository.findAllByRetailCustomerId(customer.getId());
+
+		String approvedScope = isAllow
+				? authorizeScreenService.computeApprovedScope(
+						outbound.grantedScope(), selectedUps, approvedPii, customerUsagePoints)
+				: null;
+
+		String consent = (isAllow && approvedScope != null)
+				? SignedHandoff.Return.CONSENT_ALLOW
+				: SignedHandoff.Return.CONSENT_DENY;
+
+		Instant now = clock.instant();
+		SignedHandoff.Return returnPayload = SignedHandoff.Return.of(
+				outbound.correlationId(),
+				now,
+				now.plus(RETURN_HANDOFF_TTL),
+				nonceService.generate(),
+				String.valueOf(customer.getId()),
+				List.copyOf(selectedUps),
+				/* customerResourceUri */ null, // DC produces the actual URI in PR B2's flow; the
+				                                // Return handoff just signals approvalshapes
+				consent,
+				approvedScope);
+
+		String returnToken = codec.encode(returnPayload);
+		String separator = outbound.returnUrl().contains("?") ? "&" : "?";
+		log.info("Authorization Screen: client={}, customer={}, decision={}, ups={}, piiFbs={}, correlation_id={}",
+				application.getClientId(), customer.getId(), consent,
+				selectedUps.size(), approvedPii.size(), outbound.correlationId());
+
+		return "redirect:" + outbound.returnUrl() + separator + "handoff=" + returnToken;
+	}
+
+	@ExceptionHandler(InvalidHandoffException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public String handleInvalidHandoff(InvalidHandoffException e, HttpServletRequest request) {
+		// Internal: full diagnostic for security audit
+		log.warn("Authorization Screen handoff rejected: cause='{}', remoteAddr={}, userAgent='{}', path={}",
+				e.getMessage(),
+				request.getRemoteAddr(),
+				request.getHeader("User-Agent"),
+				request.getRequestURI());
+		// External: uniform, generic, content-free
+		return "error/400";
+	}
+
+	// --- helpers --------------------------------------------------------------------------
+
+	private SignedHandoff.Outbound decodeAndConsume(String handoffToken) {
+		SignedHandoff.Outbound outbound = codec.decodeOutbound(handoffToken);
+		nonceService.consume(outbound.nonce(), outbound.expiresAt());
+		return outbound;
+	}
+
+	private RetailCustomerEntity customerOrReject(UserDetails principal) {
+		if (principal == null || principal.getUsername() == null) {
+			throw new InvalidHandoffException("no authenticated principal on Authorization Screen request");
+		}
+		return retailCustomerRepository.findByUsername(principal.getUsername())
+				.orElseThrow(() -> new InvalidHandoffException(
+						"authenticated username has no RetailCustomer row: " + principal.getUsername()));
+	}
+}

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenService.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenService.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2025 Green Button Alliance, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.greenbuttonalliance.espi.datacustodian.web.authorize;
+
+import lombok.RequiredArgsConstructor;
+import org.greenbuttonalliance.espi.common.domain.common.ServiceCategory;
+import org.greenbuttonalliance.espi.common.domain.usage.ApplicationInformationEntity;
+import org.greenbuttonalliance.espi.common.domain.usage.UsagePointEntity;
+import org.greenbuttonalliance.espi.common.domain.usage.enums.ServiceKind;
+import org.greenbuttonalliance.espi.common.handoff.InvalidHandoffException;
+import org.greenbuttonalliance.espi.common.repositories.usage.ApplicationInformationRepository;
+import org.greenbuttonalliance.espi.common.repositories.usage.UsagePointRepository;
+import org.greenbuttonalliance.espi.common.scope.EspiScope;
+import org.greenbuttonalliance.espi.common.scope.FunctionBlock;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Pure business logic backing the Authorization Screen. Lives separately from
+ * {@link AuthorizeScreenController} so the FB-subset validation, scope-narrowing, and view-model
+ * construction can be unit-tested without spinning up Spring web context.
+ *
+ * <p>This service does NOT verify the signed handoff or consume the nonce &mdash; those are the
+ * controller's responsibility (they're cross-cutting input verification, not authorization-screen
+ * logic). The service starts from an already-verified {@code grantedScope} string.</p>
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthorizeScreenService {
+
+	private final ApplicationInformationRepository applicationInformationRepository;
+	private final UsagePointRepository usagePointRepository;
+	private final MessageSource messages;
+
+	/**
+	 * Validate the requesting third party and that the granted scope is a subset of what the third
+	 * party registered. Throws {@link InvalidHandoffException} on any failure &mdash; the
+	 * controller catches that and renders the uniform 400 error page.
+	 *
+	 * @param clientId       client_id from the verified outbound handoff
+	 * @param grantedScope   scope from the verified outbound handoff
+	 * @return the resolved {@link ApplicationInformationEntity}
+	 * @throws InvalidHandoffException if the client_id is unknown or the granted scope's FB set
+	 *                                 is not a subset of any combination of the third party's
+	 *                                 registered scopes (defense in depth: AS is supposed to
+	 *                                 enforce this at {@code /authorize}, DC re-verifies)
+	 */
+	public ApplicationInformationEntity validateClientAndScope(String clientId, String grantedScope) {
+		ApplicationInformationEntity application = applicationInformationRepository
+				.findByClientId(clientId)
+				.orElseThrow(() -> new InvalidHandoffException("unknown client_id"));
+
+		Set<Integer> requestedFbs = parseScope(grantedScope).functionBlocks();
+		Set<Integer> registeredFbs = registeredFbSet(application);
+		if (!registeredFbs.containsAll(requestedFbs)) {
+			throw new InvalidHandoffException(
+					"scope contains FB(s) not registered by client_id " + clientId + ": "
+							+ requestedFbs.stream().filter(fb -> !registeredFbs.contains(fb)).toList());
+		}
+		return application;
+	}
+
+	/** Build the view model for the GET render. Customer authentication is assumed already done. */
+	public AuthorizeScreenViewModel buildViewModel(ApplicationInformationEntity application,
+												   String grantedScope,
+												   Long retailCustomerId,
+												   String handoffToken,
+												   Locale locale) {
+		EspiScope scope = parseScope(grantedScope);
+
+		List<UsagePointEntity> customerUsagePoints =
+				usagePointRepository.findAllByRetailCustomerId(retailCustomerId);
+
+		List<AuthorizeScreenViewModel.CommoditySection> commoditySections =
+				buildCommoditySections(scope, customerUsagePoints, locale);
+
+		List<AuthorizeScreenViewModel.PiiOption> piiOptions = buildPiiOptions(scope, locale);
+
+		List<String> implicitBaseLabels = scope.functionBlocks().stream()
+				.filter(FunctionBlock::isImplicitBase)
+				.sorted()
+				.map(fb -> i18n("fb." + leftPad(fb) + ".label", locale))
+				.toList();
+
+		return new AuthorizeScreenViewModel(
+				resolveTpDisplayName(application),
+				commoditySections,
+				piiOptions,
+				implicitBaseLabels,
+				handoffToken);
+	}
+
+	/**
+	 * Compute the effective approved scope from the customer's checkbox decisions. The original
+	 * granted scope is narrowed by:
+	 * <ul>
+	 *   <li>Commodity FBs: kept if at least one usage point of that commodity was selected.
+	 *       Commodities the customer rejected entirely (no usage points checked) are dropped.</li>
+	 *   <li>Energy data-shape FBs: kept if any commodity FB remains (data-shape modifiers only
+	 *       matter alongside energy data).</li>
+	 *   <li>Customer/PII FBs: kept only if the customer explicitly opted in.</li>
+	 *   <li>Implicit base FBs (1, 4, 51): kept iff still relevant after the above narrowing
+	 *       (energy bases iff any commodity remains; customer base iff any PII remains).</li>
+	 *   <li>Other terms (IntervalDuration, BlockDuration, HistoryLength): preserved.</li>
+	 * </ul>
+	 *
+	 * @return the narrowed scope string, or {@code null} if the customer denied everything
+	 *         (no usage points selected AND no PII opt-ins)
+	 */
+	public String computeApprovedScope(String originalScope,
+									   Set<UUID> selectedUsagePointIds,
+									   Set<Integer> approvedPiiFbs,
+									   List<UsagePointEntity> customerUsagePoints) {
+		EspiScope scope = parseScope(originalScope);
+
+		// Which commodities are still represented by at least one selected usage point?
+		Set<ServiceKind> grantedKinds = EnumSet.noneOf(ServiceKind.class);
+		customerUsagePoints.stream()
+				.filter(up -> selectedUsagePointIds.contains(up.getId()))
+				.map(up -> toServiceKind(up.getServiceCategory()))
+				.filter(k -> k != null)
+				.forEach(grantedKinds::add);
+
+		Set<Integer> keptFbs = new TreeSet<>();
+		for (Integer fb : scope.functionBlocks()) {
+			if (FunctionBlock.isCommodityProfile(fb)) {
+				// Keep the commodity profile only if its commodity has at least one selected up.
+				// Special case FB 29 (Temperature): no XSD ServiceKind, can't pair to a UsagePoint
+				// via standard mapping — drop unless explicitly granted via PII analogue (out of
+				// scope here; FB 29 is a known standard gap).
+				FunctionBlock.byId(fb).ifPresent(f -> {
+					if (f.getServiceKind().map(grantedKinds::contains).orElse(false)) {
+						keptFbs.add(fb);
+					}
+				});
+			}
+			else if (FunctionBlock.isPiiSelectable(fb)) {
+				if (approvedPiiFbs.contains(fb)) {
+					keptFbs.add(fb);
+				}
+			}
+			else if (FunctionBlock.isDataShapeModifier(fb)) {
+				// Data-shape modifiers only matter if some commodity is being granted.
+				if (!grantedKinds.isEmpty()) {
+					keptFbs.add(fb);
+				}
+			}
+			else if (FunctionBlock.isImplicitBase(fb)) {
+				// Implicit-base FBs are added below from the outcome, not preserved from input.
+			}
+			else {
+				// Unknown / non-screen-aware FB: preserve as-is (defensive — the AS will further
+				// reject anything truly invalid).
+				keptFbs.add(fb);
+			}
+		}
+
+		// Implicit base FBs are added based on the OUTCOME, not on whether they were in the
+		// original scope: they are by definition structural prerequisites — the response cannot
+		// be well-formed without them. Auto-adding here avoids the case where the TP requests
+		// "FB=4_54" without FB 51 and the DC emits malformed customer feed content.
+		if (!grantedKinds.isEmpty()) {
+			keptFbs.add(1);   // Common (Energy Usage)
+			keptFbs.add(4);   // Interval Metering registry
+		}
+		if (!approvedPiiFbs.isEmpty()) {
+			keptFbs.add(51);  // Common (Retail Customer)
+		}
+
+		if (grantedKinds.isEmpty() && approvedPiiFbs.isEmpty()) {
+			return null;
+		}
+		return rebuildScope(scope, keptFbs);
+	}
+
+	// --- helpers --------------------------------------------------------------------------
+
+	private List<AuthorizeScreenViewModel.CommoditySection> buildCommoditySections(
+			EspiScope scope, List<UsagePointEntity> customerUsagePoints, Locale locale) {
+
+		Set<ServiceKind> requestedKinds = scope.commodityServiceKinds();
+		if (requestedKinds.isEmpty()) {
+			return List.of();
+		}
+
+		// Group profile FBs and data-shape FBs by category for the section labels.
+		List<Integer> profileFbsSorted = scope.functionBlocks().stream()
+				.filter(FunctionBlock::isCommodityProfile)
+				.sorted().toList();
+		List<String> dataShapeLabels = scope.functionBlocks().stream()
+				.filter(FunctionBlock::isDataShapeModifier)
+				.sorted()
+				.map(fb -> i18n("fb." + leftPad(fb) + ".label", locale))
+				.toList();
+
+		List<AuthorizeScreenViewModel.CommoditySection> sections = new ArrayList<>(requestedKinds.size());
+		for (ServiceKind kind : sortedKinds(requestedKinds)) {
+			List<AuthorizeScreenViewModel.UsagePointChoice> ups = customerUsagePoints.stream()
+					.filter(up -> kind == toServiceKind(up.getServiceCategory()))
+					.sorted(Comparator.comparing(UsagePointEntity::getId))
+					.map(up -> new AuthorizeScreenViewModel.UsagePointChoice(
+							up.getId(),
+							describeUsagePoint(up, locale)))
+					.toList();
+
+			List<String> profileLabelsForKind = profileFbsSorted.stream()
+					.filter(fb -> FunctionBlock.byId(fb)
+							.flatMap(FunctionBlock::getServiceKind)
+							.map(k -> k == kind).orElse(false))
+					.map(fb -> i18n("fb." + leftPad(fb) + ".label", locale))
+					.toList();
+
+			sections.add(new AuthorizeScreenViewModel.CommoditySection(
+					i18n("commodity." + kind.name().toLowerCase(Locale.ROOT) + ".title", locale),
+					kind,
+					ups,
+					profileLabelsForKind,
+					dataShapeLabels));
+		}
+		return sections;
+	}
+
+	private List<AuthorizeScreenViewModel.PiiOption> buildPiiOptions(EspiScope scope, Locale locale) {
+		return scope.functionBlocks().stream()
+				.filter(FunctionBlock::isPiiSelectable)
+				.sorted()
+				.map(fb -> new AuthorizeScreenViewModel.PiiOption(
+						fb,
+						i18n("fb." + leftPad(fb) + ".label", locale),
+						i18n("fb." + leftPad(fb) + ".description", locale)))
+				.toList();
+	}
+
+	private Set<Integer> registeredFbSet(ApplicationInformationEntity application) {
+		Set<Integer> fbs = new TreeSet<>();
+		for (String registered : application.getScope()) {
+			try {
+				fbs.addAll(EspiScope.parse(registered).functionBlocks());
+			}
+			catch (IllegalArgumentException ignored) {
+				// A malformed registered scope is a registration-time bug; conservatively skip it.
+			}
+		}
+		return fbs;
+	}
+
+	private String resolveTpDisplayName(ApplicationInformationEntity application) {
+		String desc = application.getThirdPartyApplicationDescription();
+		if (desc != null && !desc.isBlank()) return desc;
+		return application.getClientId();
+	}
+
+	private String describeUsagePoint(UsagePointEntity up, Locale locale) {
+		// Sandbox-friendly: kind + short id. Production utilities would override the template
+		// or supply a localized description from their CRM.
+		String kindLabel = up.getServiceCategory() != null
+				? i18n("commodity." + up.getServiceCategory().name().toLowerCase(Locale.ROOT) + ".title", locale)
+				: "Unknown";
+		String shortId = up.getId() != null ? up.getId().toString().substring(0, 8) : "?";
+		return kindLabel + " (" + shortId + ")";
+	}
+
+	private static EspiScope parseScope(String raw) {
+		try {
+			return EspiScope.parse(raw);
+		}
+		catch (IllegalArgumentException e) {
+			throw new InvalidHandoffException("unparseable scope", e);
+		}
+	}
+
+	private static String rebuildScope(EspiScope original, Set<Integer> keptFbs) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("FB=").append(keptFbs.stream().map(String::valueOf).collect(Collectors.joining("_")));
+		if (original.intervalDuration() != null) {
+			sb.append(";IntervalDuration=").append(original.intervalDuration());
+		}
+		if (original.blockDuration() != null) {
+			sb.append(";BlockDuration=").append(original.blockDuration());
+		}
+		if (original.historyLength() != null) {
+			sb.append(";HistoryLength=").append(original.historyLength());
+		}
+		original.additionalParameters().forEach((k, v) -> {
+			sb.append(';').append(k);
+			if (!v.isEmpty()) sb.append('=').append(v);
+		});
+		return sb.toString();
+	}
+
+	private static ServiceKind toServiceKind(ServiceCategory category) {
+		if (category == null) return null;
+		try {
+			return ServiceKind.valueOf(category.name());
+		}
+		catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+
+	private static List<ServiceKind> sortedKinds(Set<ServiceKind> kinds) {
+		return kinds.stream().sorted(Comparator.comparingInt(ServiceKind::getValue)).toList();
+	}
+
+	private String i18n(String key, Locale locale) {
+		return messages.getMessage(key, null, key, locale);
+	}
+
+	private static String leftPad(int fbId) {
+		return fbId < 10 ? "0" + fbId : String.valueOf(fbId);
+	}
+}

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenViewModel.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenViewModel.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Green Button Alliance, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.greenbuttonalliance.espi.datacustodian.web.authorize;
+
+import org.greenbuttonalliance.espi.common.domain.usage.enums.ServiceKind;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * View model for the Authorization Screen (PR C2b). All strings here are pre-localized by the
+ * controller against the current request locale; the template renders raw values without further
+ * i18n lookups.
+ *
+ * @param tpName                Customer-visible name of the third party (from
+ *                              {@code ApplicationInformation.thirdPartyApplicationDescription},
+ *                              falling back to {@code client_id})
+ * @param commoditySections     One section per {@link ServiceKind} present in the requested scope,
+ *                              ordered electricity &rarr; gas &rarr; water &rarr; temperature.
+ *                              Empty if the grant is PII-only.
+ * @param piiOptions            One entry per Customer/PII FB in the requested scope. Customer
+ *                              checks each individually (default-unchecked).
+ * @param implicitBaseLabels    Display-only footer note for FB 1 / 4 / 51 that are part of the
+ *                              grant but are not customer-selectable (structural prerequisites).
+ * @param handoffToken          The signed outbound handoff token, round-tripped through the form
+ *                              as a hidden field so the POST handler can re-verify and rebuild the
+ *                              return payload.
+ */
+public record AuthorizeScreenViewModel(
+		String tpName,
+		List<CommoditySection> commoditySections,
+		List<PiiOption> piiOptions,
+		List<String> implicitBaseLabels,
+		String handoffToken
+) {
+
+	/**
+	 * One commodity (electricity / gas / water / temperature) section. The customer toggles
+	 * individual usage points; the {@code profileLabels} and {@code dataShapeLabels} are
+	 * display-only ("this is what you'll receive") because the third party chose those when
+	 * requesting the scope, not the customer.
+	 *
+	 * @param sectionTitle      Localized commodity title (e.g. "Electricity")
+	 * @param kind              The {@link ServiceKind} this section covers
+	 * @param usagePoints       Customer's usage points of this commodity that are eligible to be
+	 *                          shared; empty if the customer has no usage points of this kind
+	 * @param profileLabels     Localized labels for the commodity-profile FBs in the requested
+	 *                          scope that apply to this commodity (e.g. "Hourly delivered",
+	 *                          "Solar export")
+	 * @param dataShapeLabels   Localized labels for the data-shape FBs in the requested scope
+	 *                          (e.g. "Billing-period summaries", "Power quality"). These are
+	 *                          orthogonal to commodity but rendered under each section so the
+	 *                          customer can see what's included.
+	 */
+	public record CommoditySection(
+			String sectionTitle,
+			ServiceKind kind,
+			List<UsagePointChoice> usagePoints,
+			List<String> profileLabels,
+			List<String> dataShapeLabels
+	) {}
+
+	/**
+	 * A customer usage point the third party may receive data for. Customer toggles a checkbox per
+	 * choice (default-checked &mdash; the third party explicitly requested the matching commodity).
+	 *
+	 * @param id           UUID; round-trips through the form to identify the customer's selection
+	 * @param description  Localized human-readable description (kind + meter/location identifier)
+	 */
+	public record UsagePointChoice(
+			UUID id,
+			String description
+	) {}
+
+	/**
+	 * A Customer/PII consent option. One per PII FB in the requested scope. Default-unchecked;
+	 * customer must explicitly opt in to each.
+	 *
+	 * @param fbId         The FB number (54&ndash;62) &mdash; round-trips through the form
+	 * @param label        Localized short label (e.g. "Your mailing address")
+	 * @param description  Localized one-line description of what the third party receives
+	 */
+	public record PiiOption(
+			int fbId,
+			String label,
+			String description
+	) {}
+}

--- a/openespi-datacustodian/src/main/resources/messages.properties
+++ b/openespi-datacustodian/src/main/resources/messages.properties
@@ -1,0 +1,100 @@
+# Customer-facing strings for the OpenESPI Data Custodian.
+#
+# Spring Boot's default MessageSource auto-loads this file as the i18n fallback. Locale-specific
+# overrides go in messages_<lang>.properties (e.g. messages_es.properties, messages_fr_CA.properties).
+# Production utilities can override any key by dropping their own resource file ahead on the
+# classpath.
+#
+# Convention: keys are dot.delimited, with namespace prefix:
+#   fb.NN.label       — short customer-facing name for FB number NN
+#   fb.NN.description — one-line description of what the third party receives
+#   screen.*          — Authorization Screen UI strings
+#   error.*           — Error page strings
+
+# --- Function Block labels and descriptions -------------------------------------------------
+# Labels in this file are the XSLT-verified mapping (GBA conformance scripts) from FB id to
+# what the third party actually receives in the response. See issue #141 for details.
+
+# Base (implicit; never customer-selectable, shown as a footer note)
+fb.01.label=Service identity (energy feed)
+fb.01.description=your usage point identifier, service category, and timezone
+fb.04.label=Meter readings registry
+fb.04.description=the lookup structure for your meter data
+fb.51.label=Service identity (customer record)
+fb.51.description=the timezone associated with your customer record
+
+# Commodity profiles (display-only sub-lines under a commodity section)
+fb.05.label=Hourly electricity usage
+fb.05.description=electricity delivered to your service, watt-hour interval readings
+fb.06.label=Peak electricity demand
+fb.06.description=your demand (kW) and rate-of-consumption summaries
+fb.07.label=Net electricity
+fb.07.description=net energy after on-site generation (consumption minus solar/wind export)
+fb.08.label=Electricity export
+fb.08.description=energy you export back to the grid (e.g. from solar panels)
+fb.09.label=Cumulative electricity register
+fb.09.description=bulk register readings (total-since-install style)
+fb.10.label=Natural gas usage
+fb.10.description=gas consumption by volume or energy
+fb.11.label=Water usage
+fb.11.description=water consumption by volume
+fb.29.label=Temperature readings
+fb.29.description=outside-air or similar temperature data tied to your usage point
+
+# Data-shape modifiers (display-only sub-lines under each commodity section)
+fb.12.label=Time-series interval data
+fb.12.description=your individual time-stamped meter reads
+fb.15.label=Billing-period usage summaries
+fb.15.description=your billing-period totals (this period and last period)
+fb.16.label=Billing amounts and costs
+fb.16.description=billed amounts in your currency for this and previous billing periods
+fb.17.label=Electric power quality
+fb.17.description=voltage, frequency, and other power-quality summary metrics
+fb.27.label=Daily usage summaries
+fb.27.description=current day and previous day total consumption and peak demand
+fb.28.label=Bill-to-date status
+fb.28.description=running total of your current bill so far this period
+
+# Customer/PII (individually selectable consent checkboxes)
+fb.54.label=Your customer record
+fb.54.description=your customer name
+fb.55.label=Your mailing address
+fb.55.description=street, city, and state on your customer record
+fb.56.label=Your billing account
+fb.56.description=account number and billing contact details
+fb.57.label=Your service agreement
+fb.57.description=your rate plan / contract record
+fb.58.label=Your service location
+fb.58.description=where your service is delivered
+fb.59.label=Your service supplier
+fb.59.description=the entity providing your service
+fb.60.label=Your meter
+fb.60.description=meter device serial number
+fb.61.label=Connected devices
+fb.61.description=registered end-device serial numbers (smart thermostat, EV charger, etc.)
+fb.62.label=Program participation history
+fb.62.description=demand-response or similar program enrollment dates
+
+# Commodity / ServiceKind section titles (used to group usage points)
+commodity.electricity.title=Electricity
+commodity.gas.title=Natural gas
+commodity.water.title=Water
+commodity.temperature.title=Temperature
+
+# --- Authorization Screen UI strings --------------------------------------------------------
+screen.title=Authorize {0}
+screen.heading=Authorize access for {0}
+screen.subheading=Review what {0} is requesting access to. Uncheck anything you do NOT wish to share.
+screen.energy.heading=Energy data
+screen.energy.includes=This application will receive:
+screen.energy.empty=You have no eligible usage points for this request.
+screen.pii.heading=Personal information
+screen.pii.opt-in-note=Each of these is shared only if you explicitly check it.
+screen.implicit.note=Always included for any energy or customer-data grant: {0}
+screen.allow=Allow
+screen.deny=Deny
+screen.cancel=Cancel
+
+# --- Error pages ----------------------------------------------------------------------------
+error.400.title=Bad Request
+error.400.message=This authorization request cannot be processed. Please return to the application that sent you here and try again.

--- a/openespi-datacustodian/src/main/resources/templates/authorize-screen.html
+++ b/openespi-datacustodian/src/main/resources/templates/authorize-screen.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/layout :: head}">
+    <title th:text="#{screen.title(${viewModel.tpName})}">Authorize</title>
+</head>
+
+<body>
+    <nav th:replace="~{fragments/layout :: header}"></nav>
+
+    <div class="container">
+        <div class="row justify-content-center mt-4">
+            <div class="col-lg-8">
+                <div class="card">
+                    <div class="card-header bg-primary text-white">
+                        <h4 class="mb-0" th:text="#{screen.heading(${viewModel.tpName})}">Authorize access</h4>
+                    </div>
+                    <div class="card-body">
+                        <p class="lead" th:text="#{screen.subheading(${viewModel.tpName})}">
+                            Review what this application is requesting access to.
+                        </p>
+
+                        <!-- th:action emits the CSRF token automatically -->
+                        <form th:action="@{/oauth/authorize-screen}" method="post">
+                            <input type="hidden" name="handoff" th:value="${viewModel.handoffToken}">
+
+                            <!-- Energy data sections (one per commodity) -->
+                            <div th:if="${not #lists.isEmpty(viewModel.commoditySections)}" class="mb-4">
+                                <h5 th:text="#{screen.energy.heading}">Energy data</h5>
+                                <div th:each="section : ${viewModel.commoditySections}" class="card mb-3">
+                                    <div class="card-header bg-light">
+                                        <strong th:text="${section.sectionTitle}">Commodity</strong>
+                                    </div>
+                                    <div class="card-body">
+                                        <!-- Usage points (customer-selectable, default-checked) -->
+                                        <div th:if="${not #lists.isEmpty(section.usagePoints)}">
+                                            <div th:each="up : ${section.usagePoints}" class="form-check">
+                                                <input class="form-check-input"
+                                                       type="checkbox"
+                                                       name="selected_usage_point_ids"
+                                                       th:value="${up.id}"
+                                                       th:id="'up_' + ${up.id}"
+                                                       checked>
+                                                <label class="form-check-label" th:for="'up_' + ${up.id}"
+                                                       th:text="${up.description}">Usage point</label>
+                                            </div>
+                                        </div>
+                                        <div th:if="${#lists.isEmpty(section.usagePoints)}"
+                                             class="alert alert-warning small mb-0">
+                                            <span th:text="#{screen.energy.empty}">No eligible usage points.</span>
+                                        </div>
+
+                                        <!-- Profile + data-shape modifiers (display-only) -->
+                                        <div th:if="${not #lists.isEmpty(section.profileLabels) or not #lists.isEmpty(section.dataShapeLabels)}"
+                                             class="mt-2 small text-muted">
+                                            <div th:text="#{screen.energy.includes}">This application will receive:</div>
+                                            <ul class="mb-0">
+                                                <li th:each="label : ${section.profileLabels}" th:text="${label}">Profile</li>
+                                                <li th:each="label : ${section.dataShapeLabels}" th:text="${label}">Data shape</li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- PII consent options (each individually opt-in, default-unchecked) -->
+                            <div th:if="${not #lists.isEmpty(viewModel.piiOptions)}" class="mb-4">
+                                <h5 th:text="#{screen.pii.heading}">Personal information</h5>
+                                <p class="small text-muted" th:text="#{screen.pii.opt-in-note}">
+                                    Each of these is shared only if you explicitly check it.
+                                </p>
+                                <div th:each="pii : ${viewModel.piiOptions}" class="form-check mb-2">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           name="approved_pii_fbs"
+                                           th:value="${pii.fbId}"
+                                           th:id="'pii_' + ${pii.fbId}">
+                                    <label class="form-check-label" th:for="'pii_' + ${pii.fbId}">
+                                        <strong th:text="${pii.label}">PII label</strong>
+                                        <small class="text-muted d-block" th:text="${pii.description}">PII description</small>
+                                    </label>
+                                </div>
+                            </div>
+
+                            <!-- Implicit base FBs (display-only footer) -->
+                            <div th:if="${not #lists.isEmpty(viewModel.implicitBaseLabels)}"
+                                 class="mb-4 small text-muted">
+                                <span th:text="#{screen.implicit.note(${#strings.listJoin(viewModel.implicitBaseLabels, ', ')})}">
+                                    Always included: ...
+                                </span>
+                            </div>
+
+                            <!-- Allow / Deny -->
+                            <div class="d-flex justify-content-end gap-2">
+                                <button type="submit" name="decision" value="deny"
+                                        class="btn btn-outline-secondary"
+                                        th:text="#{screen.deny}">Deny</button>
+                                <button type="submit" name="decision" value="allow"
+                                        class="btn btn-primary"
+                                        th:text="#{screen.allow}">Allow</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <footer th:replace="~{fragments/layout :: footer}"></footer>
+    </div>
+
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+</body>
+</html>

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenControllerTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2025 Green Button Alliance, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.greenbuttonalliance.espi.datacustodian.web.authorize;
+
+import org.greenbuttonalliance.espi.common.domain.common.ServiceCategory;
+import org.greenbuttonalliance.espi.common.domain.usage.ApplicationInformationEntity;
+import org.greenbuttonalliance.espi.common.domain.usage.RetailCustomerEntity;
+import org.greenbuttonalliance.espi.common.domain.usage.UsagePointEntity;
+import org.greenbuttonalliance.espi.common.handoff.SignedHandoff;
+import org.greenbuttonalliance.espi.common.handoff.SignedHandoffCodec;
+import org.greenbuttonalliance.espi.common.repositories.usage.ApplicationInformationRepository;
+import org.greenbuttonalliance.espi.common.repositories.usage.RetailCustomerRepository;
+import org.greenbuttonalliance.espi.common.repositories.usage.UsagePointRepository;
+import org.greenbuttonalliance.espi.common.scope.EspiScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * MockMvc tests for {@link AuthorizeScreenController} — the customer-facing Authorization Screen.
+ *
+ * <p>Covers the security boundary (invalid-handoff rejection variants, all surfacing as a uniform
+ * 400) and the happy-path GET / POST round trip (handoff verification, nonce consumption,
+ * effective-scope computation, signed return handoff back to the AS).</p>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthorizeScreenControllerTest {
+
+	private static final String TP_CLIENT_ID = "tp-screen-test";
+	private static final String CUSTOMER_USERNAME = "screen-test-customer";
+	private static final String CUSTOMER_PASSWORD = "secret123";
+
+	@Autowired private MockMvc mockMvc;
+	@Autowired private SignedHandoffCodec codec;
+	@Autowired private ApplicationInformationRepository applicationInformationRepository;
+	@Autowired private RetailCustomerRepository retailCustomerRepository;
+	@Autowired private UsagePointRepository usagePointRepository;
+	@Autowired private PasswordEncoder customerPasswordEncoder;
+
+	private RetailCustomerEntity customer;
+	private ApplicationInformationEntity application;
+	private UUID electricityUpId;
+	private UUID gasUpId;
+
+	@BeforeEach
+	void seedFixtures() {
+		application = applicationInformationRepository.findByClientId(TP_CLIENT_ID)
+				.orElseGet(() -> {
+					ApplicationInformationEntity app = new ApplicationInformationEntity();
+					app.setId(UUID.randomUUID());
+					app.setClientId(TP_CLIENT_ID);
+					app.setThirdPartyApplicationDescription("Test Third Party");
+					app.setScope(new HashSet<>(List.of("FB=4_5_10_15_54_58")));
+					return applicationInformationRepository.save(app);
+				});
+
+		customer = retailCustomerRepository.findByUsername(CUSTOMER_USERNAME)
+				.orElseGet(() -> {
+					RetailCustomerEntity c = new RetailCustomerEntity(CUSTOMER_USERNAME, "Screen", "Tester");
+					c.setPassword(customerPasswordEncoder.encode(CUSTOMER_PASSWORD));
+					c.setRole(RetailCustomerEntity.ROLE_USER);
+					c.setEnabled(Boolean.TRUE);
+					c.setAccountLocked(Boolean.FALSE);
+					return retailCustomerRepository.save(c);
+				});
+
+		if (usagePointRepository.findAllByRetailCustomerId(customer.getId()).isEmpty()) {
+			UsagePointEntity elec = new UsagePointEntity();
+			elec.setId(UUID.randomUUID());
+			elec.setServiceCategory(ServiceCategory.ELECTRICITY);
+			elec.setRetailCustomer(customer);
+			electricityUpId = usagePointRepository.save(elec).getId();
+
+			UsagePointEntity gas = new UsagePointEntity();
+			gas.setId(UUID.randomUUID());
+			gas.setServiceCategory(ServiceCategory.GAS);
+			gas.setRetailCustomer(customer);
+			gasUpId = usagePointRepository.save(gas).getId();
+		}
+		else {
+			List<UsagePointEntity> ups = usagePointRepository.findAllByRetailCustomerId(customer.getId());
+			electricityUpId = ups.stream()
+					.filter(u -> u.getServiceCategory() == ServiceCategory.ELECTRICITY)
+					.findFirst().orElseThrow().getId();
+			gasUpId = ups.stream()
+					.filter(u -> u.getServiceCategory() == ServiceCategory.GAS)
+					.findFirst().orElseThrow().getId();
+		}
+	}
+
+	@Test
+	void invalid_handoff_returns_400_uniform_page() throws Exception {
+		mockMvc.perform(get("/oauth/authorize-screen")
+						.param("handoff", "not-a-valid-handoff")
+						.with(user(CUSTOMER_USERNAME).roles("USER")))
+				.andExpect(status().isBadRequest())
+				.andExpect(content().string(org.hamcrest.Matchers.containsString("Bad Request")));
+	}
+
+	@Test
+	void unknown_client_id_returns_400() throws Exception {
+		String token = codec.encode(SignedHandoff.Outbound.of(
+				"corr-1", Instant.now(), Instant.now().plusSeconds(120), UUID.randomUUID().toString(),
+				"ghost-client", "FB=4_5_15", "https://as.example.com/continue"));
+
+		mockMvc.perform(get("/oauth/authorize-screen")
+						.param("handoff", token)
+						.with(user(CUSTOMER_USERNAME).roles("USER")))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void scope_escalation_beyond_registered_returns_400() throws Exception {
+		// TP registered FB=4_5_10_15_54_58; request a non-registered FB (e.g. 16)
+		String token = codec.encode(SignedHandoff.Outbound.of(
+				"corr-2", Instant.now(), Instant.now().plusSeconds(120), UUID.randomUUID().toString(),
+				TP_CLIENT_ID, "FB=4_5_16", "https://as.example.com/continue"));
+
+		mockMvc.perform(get("/oauth/authorize-screen")
+						.param("handoff", token)
+						.with(user(CUSTOMER_USERNAME).roles("USER")))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void replayed_nonce_returns_400() throws Exception {
+		String reusedNonce = UUID.randomUUID().toString();
+		String token = codec.encode(SignedHandoff.Outbound.of(
+				"corr-3", Instant.now(), Instant.now().plusSeconds(120), reusedNonce,
+				TP_CLIENT_ID, "FB=4_5_15", "https://as.example.com/continue"));
+
+		// First request consumes the nonce.
+		mockMvc.perform(get("/oauth/authorize-screen")
+						.param("handoff", token)
+						.with(user(CUSTOMER_USERNAME).roles("USER")))
+				.andExpect(status().isOk());
+
+		// Second request with the same nonce must be rejected.
+		mockMvc.perform(get("/oauth/authorize-screen")
+						.param("handoff", token)
+						.with(user(CUSTOMER_USERNAME).roles("USER")))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void happy_GET_renders_form_with_tp_name_and_csrf() throws Exception {
+		String token = codec.encode(SignedHandoff.Outbound.of(
+				"corr-4", Instant.now(), Instant.now().plusSeconds(120), UUID.randomUUID().toString(),
+				TP_CLIENT_ID, "FB=4_5_15", "https://as.example.com/continue"));
+
+		mockMvc.perform(get("/oauth/authorize-screen")
+						.param("handoff", token)
+						.with(user(CUSTOMER_USERNAME).roles("USER")))
+				.andExpect(status().isOk())
+				.andExpect(content().string(org.hamcrest.Matchers.containsString("Test Third Party")))
+				.andExpect(content().string(org.hamcrest.Matchers.containsString("name=\"handoff\"")))
+				.andExpect(content().string(org.hamcrest.Matchers.containsString("name=\"_csrf\"")))
+				.andExpect(content().string(org.hamcrest.Matchers.containsString("selected_usage_point_ids")));
+	}
+
+	@Test
+	void POST_allow_redirects_to_AS_with_signed_return_handoff_carrying_approved_scope() throws Exception {
+		String token = codec.encode(SignedHandoff.Outbound.of(
+				"corr-5", Instant.now(), Instant.now().plusSeconds(120), UUID.randomUUID().toString(),
+				TP_CLIENT_ID, "FB=4_5_10_15_54_58", "https://as.example.com/continue?state=abc"));
+
+		MvcResult result = mockMvc.perform(post("/oauth/authorize-screen")
+						.with(csrf())
+						.with(user(CUSTOMER_USERNAME).roles("USER"))
+						.param("handoff", token)
+						.param("decision", "allow")
+						.param("selected_usage_point_ids", electricityUpId.toString())
+						.param("approved_pii_fbs", "54"))
+				.andExpect(status().is3xxRedirection())
+				.andExpect(redirectedUrlPattern("https://as.example.com/continue?state=abc&handoff=*"))
+				.andReturn();
+
+		String location = result.getResponse().getHeader("Location");
+		String returnToken = location.substring(location.indexOf("handoff=") + "handoff=".length());
+		SignedHandoff.Return ret = codec.decodeReturn(returnToken);
+
+		assertThat(ret.consent()).isEqualTo(SignedHandoff.Return.CONSENT_ALLOW);
+		assertThat(ret.correlationId()).isEqualTo("corr-5");
+		assertThat(ret.selectedUsagePointIds()).containsExactly(electricityUpId);
+
+		// Effective approved scope: customer kept electricity (5 + implicit 1+4), data-shape 15, PII 54 (+ implicit 51).
+		// Gas (10) dropped, FB 58 dropped (customer didn't approve).
+		EspiScope approved = EspiScope.parse(ret.approvedScope());
+		assertThat(approved.functionBlocks()).containsExactly(1, 4, 5, 15, 51, 54);
+	}
+
+	@Test
+	void POST_deny_redirects_to_AS_with_deny_handoff_no_approved_scope() throws Exception {
+		String token = codec.encode(SignedHandoff.Outbound.of(
+				"corr-6", Instant.now(), Instant.now().plusSeconds(120), UUID.randomUUID().toString(),
+				TP_CLIENT_ID, "FB=4_5_15", "https://as.example.com/continue"));
+
+		MvcResult result = mockMvc.perform(post("/oauth/authorize-screen")
+						.with(csrf())
+						.with(user(CUSTOMER_USERNAME).roles("USER"))
+						.param("handoff", token)
+						.param("decision", "deny"))
+				.andExpect(status().is3xxRedirection())
+				.andReturn();
+
+		String location = result.getResponse().getHeader("Location");
+		String returnToken = location.substring(location.indexOf("handoff=") + "handoff=".length());
+		SignedHandoff.Return ret = codec.decodeReturn(returnToken);
+
+		assertThat(ret.consent()).isEqualTo(SignedHandoff.Return.CONSENT_DENY);
+		assertThat(ret.approvedScope()).isNull();
+		assertThat(ret.selectedUsagePointIds()).isEmpty();
+	}
+
+	@Test
+	void POST_allow_with_no_selections_falls_back_to_deny() throws Exception {
+		String token = codec.encode(SignedHandoff.Outbound.of(
+				"corr-7", Instant.now(), Instant.now().plusSeconds(120), UUID.randomUUID().toString(),
+				TP_CLIENT_ID, "FB=4_5_15_54", "https://as.example.com/continue"));
+
+		MvcResult result = mockMvc.perform(post("/oauth/authorize-screen")
+						.with(csrf())
+						.with(user(CUSTOMER_USERNAME).roles("USER"))
+						.param("handoff", token)
+						.param("decision", "allow"))
+				.andExpect(status().is3xxRedirection())
+				.andReturn();
+
+		String location = result.getResponse().getHeader("Location");
+		String returnToken = location.substring(location.indexOf("handoff=") + "handoff=".length());
+		SignedHandoff.Return ret = codec.decodeReturn(returnToken);
+
+		// Customer clicked Allow but checked nothing → effectively a deny.
+		assertThat(ret.consent()).isEqualTo(SignedHandoff.Return.CONSENT_DENY);
+		assertThat(ret.approvedScope()).isNull();
+	}
+}

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenServiceTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/authorize/AuthorizeScreenServiceTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2025 Green Button Alliance, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.greenbuttonalliance.espi.datacustodian.web.authorize;
+
+import org.greenbuttonalliance.espi.common.domain.common.ServiceCategory;
+import org.greenbuttonalliance.espi.common.domain.usage.ApplicationInformationEntity;
+import org.greenbuttonalliance.espi.common.domain.usage.UsagePointEntity;
+import org.greenbuttonalliance.espi.common.handoff.InvalidHandoffException;
+import org.greenbuttonalliance.espi.common.repositories.usage.ApplicationInformationRepository;
+import org.greenbuttonalliance.espi.common.repositories.usage.UsagePointRepository;
+import org.greenbuttonalliance.espi.common.scope.EspiScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.MessageSource;
+import org.springframework.context.support.StaticMessageSource;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AuthorizeScreenService}: client-and-scope validation (defense-in-depth FB
+ * subset check), view-model construction (commodity grouping), and scope-narrowing from customer
+ * checkbox decisions.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AuthorizeScreenServiceTest {
+
+	private static final Locale LOCALE = Locale.ENGLISH;
+	private static final String CLIENT_ID = "test-tp";
+
+	@Mock private ApplicationInformationRepository applicationInformationRepository;
+	@Mock private UsagePointRepository usagePointRepository;
+
+	private MessageSource messages;
+	private AuthorizeScreenService service;
+
+	@BeforeEach
+	void setUp() {
+		messages = staticMessages();
+		service = new AuthorizeScreenService(applicationInformationRepository, usagePointRepository, messages);
+	}
+
+	@Test
+	void validateClientAndScope_passes_when_scope_is_subset_of_registered() {
+		ApplicationInformationEntity app = appWithRegisteredScopes(
+				"FB=4_5_15;IntervalDuration=3600",
+				"FB=4_5_54");
+		when(applicationInformationRepository.findByClientId(CLIENT_ID)).thenReturn(Optional.of(app));
+
+		assertThat(service.validateClientAndScope(CLIENT_ID, "FB=4_5")).isSameAs(app);
+		assertThat(service.validateClientAndScope(CLIENT_ID, "FB=4_5_15")).isSameAs(app);
+		assertThat(service.validateClientAndScope(CLIENT_ID, "FB=4_54")).isSameAs(app);
+	}
+
+	@Test
+	void validateClientAndScope_rejects_unknown_client() {
+		when(applicationInformationRepository.findByClientId("ghost")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.validateClientAndScope("ghost", "FB=4_5_15"))
+				.isInstanceOf(InvalidHandoffException.class)
+				.hasMessageContaining("unknown client_id");
+	}
+
+	@Test
+	void validateClientAndScope_rejects_scope_escalation() {
+		ApplicationInformationEntity app = appWithRegisteredScopes("FB=4_5_15");
+		when(applicationInformationRepository.findByClientId(CLIENT_ID)).thenReturn(Optional.of(app));
+
+		assertThatThrownBy(() -> service.validateClientAndScope(CLIENT_ID, "FB=4_5_15_54"))
+				.isInstanceOf(InvalidHandoffException.class)
+				.hasMessageContaining("not registered");
+	}
+
+	@Test
+	void buildViewModel_groups_usage_points_by_requested_commodity_only() {
+		ApplicationInformationEntity app = appWithRegisteredScopes("FB=4_5_15");
+		UUID elec1 = UUID.randomUUID();
+		UUID elec2 = UUID.randomUUID();
+		UUID gas1 = UUID.randomUUID();
+		when(usagePointRepository.findAllByRetailCustomerId(42L)).thenReturn(List.of(
+				usagePoint(elec1, ServiceCategory.ELECTRICITY),
+				usagePoint(elec2, ServiceCategory.ELECTRICITY),
+				usagePoint(gas1, ServiceCategory.GAS)));
+
+		AuthorizeScreenViewModel vm = service.buildViewModel(app, "FB=4_5_15", 42L, "tok", LOCALE);
+
+		// TP only requested electricity → only one commodity section
+		assertThat(vm.commoditySections()).hasSize(1);
+		AuthorizeScreenViewModel.CommoditySection sec = vm.commoditySections().get(0);
+		assertThat(sec.usagePoints()).extracting(AuthorizeScreenViewModel.UsagePointChoice::id)
+				.containsExactlyInAnyOrder(elec1, elec2);
+		// Gas usage point is not exposed.
+	}
+
+	@Test
+	void buildViewModel_emits_section_per_requested_commodity() {
+		ApplicationInformationEntity app = appWithRegisteredScopes("FB=4_5_10_15");
+		when(usagePointRepository.findAllByRetailCustomerId(42L)).thenReturn(List.of(
+				usagePoint(UUID.randomUUID(), ServiceCategory.ELECTRICITY),
+				usagePoint(UUID.randomUUID(), ServiceCategory.GAS)));
+
+		AuthorizeScreenViewModel vm = service.buildViewModel(app, "FB=4_5_10_15", 42L, "tok", LOCALE);
+
+		assertThat(vm.commoditySections())
+				.extracting(AuthorizeScreenViewModel.CommoditySection::kind)
+				.containsExactlyInAnyOrder(
+						org.greenbuttonalliance.espi.common.domain.usage.enums.ServiceKind.ELECTRICITY,
+						org.greenbuttonalliance.espi.common.domain.usage.enums.ServiceKind.GAS);
+	}
+
+	@Test
+	void buildViewModel_emits_pii_option_per_requested_pii_fb() {
+		ApplicationInformationEntity app = appWithRegisteredScopes("FB=4_5_54_55_58");
+
+		AuthorizeScreenViewModel vm = service.buildViewModel(app, "FB=4_5_54_55_58", 42L, "tok", LOCALE);
+
+		assertThat(vm.piiOptions())
+				.extracting(AuthorizeScreenViewModel.PiiOption::fbId)
+				.containsExactly(54, 55, 58);
+	}
+
+	@Test
+	void buildViewModel_omits_pii_section_when_no_pii_scope() {
+		ApplicationInformationEntity app = appWithRegisteredScopes("FB=4_5_15");
+
+		AuthorizeScreenViewModel vm = service.buildViewModel(app, "FB=4_5_15", 42L, "tok", LOCALE);
+
+		assertThat(vm.piiOptions()).isEmpty();
+	}
+
+	@Test
+	void buildViewModel_PII_only_grant_emits_no_commodity_sections() {
+		ApplicationInformationEntity app = appWithRegisteredScopes("FB=4_54");
+
+		AuthorizeScreenViewModel vm = service.buildViewModel(app, "FB=4_54", 42L, "tok", LOCALE);
+
+		assertThat(vm.commoditySections()).isEmpty();
+		assertThat(vm.piiOptions()).extracting(AuthorizeScreenViewModel.PiiOption::fbId).containsExactly(54);
+	}
+
+	@Test
+	void computeApprovedScope_narrows_commodity_to_selected_kinds() {
+		UUID elec = UUID.randomUUID();
+		UUID gas = UUID.randomUUID();
+		List<UsagePointEntity> ups = List.of(
+				usagePoint(elec, ServiceCategory.ELECTRICITY),
+				usagePoint(gas, ServiceCategory.GAS));
+
+		// Original scope requested electricity + gas; customer kept electricity only.
+		String approved = service.computeApprovedScope(
+				"FB=4_5_10_15;IntervalDuration=3600",
+				Set.of(elec),                // only electricity selected
+				Set.of(),                    // no PII
+				ups);
+
+		EspiScope parsed = EspiScope.parse(approved);
+		// FB 1 + 4 auto-added (implicit base for any energy grant); FB 5 kept; FB 10 dropped
+		// (gas not selected); FB 15 kept (data-shape modifier valid when commodity remains).
+		assertThat(parsed.functionBlocks()).containsExactly(1, 4, 5, 15);
+		assertThat(parsed.intervalDuration()).isEqualTo(3600);
+	}
+
+	@Test
+	void computeApprovedScope_PII_only_grant_keeps_only_approved_PII_fbs() {
+		String approved = service.computeApprovedScope(
+				"FB=4_54_55_58",
+				Set.of(),
+				Set.of(54, 58),              // customer approved 54 + 58, denied 55
+				List.of());
+
+		EspiScope parsed = EspiScope.parse(approved);
+		assertThat(parsed.functionBlocks()).containsExactly(51, 54, 58); // FB 51 (customer base) added
+		// FB 55 dropped (denied); FB 4 dropped (no energy in approved scope)
+	}
+
+	@Test
+	void computeApprovedScope_adds_implicit_energy_bases_when_any_commodity_remains() {
+		UUID elec = UUID.randomUUID();
+		String approved = service.computeApprovedScope(
+				"FB=5", Set.of(elec), Set.of(),                                 // request omits FB 1 + 4
+				List.of(usagePoint(elec, ServiceCategory.ELECTRICITY)));
+
+		// Implementation auto-adds 1 + 4 (required for any energy response to be well-formed).
+		assertThat(EspiScope.parse(approved).functionBlocks()).contains(1, 4);
+	}
+
+	@Test
+	void computeApprovedScope_drops_energy_bases_for_PII_only_outcome() {
+		String approved = service.computeApprovedScope(
+				"FB=4_5_54", Set.of(), Set.of(54), List.of());
+
+		assertThat(EspiScope.parse(approved).functionBlocks()).doesNotContain(1, 4, 5);
+		assertThat(EspiScope.parse(approved).functionBlocks()).contains(54, 51);
+	}
+
+	@Test
+	void computeApprovedScope_returns_null_when_customer_grants_nothing() {
+		assertThat(service.computeApprovedScope("FB=4_5_15_54", Set.of(), Set.of(), List.of())).isNull();
+	}
+
+	// --- helpers --------------------------------------------------------------------------
+
+	private static ApplicationInformationEntity appWithRegisteredScopes(String... scopes) {
+		ApplicationInformationEntity app = new ApplicationInformationEntity();
+		app.setClientId(CLIENT_ID);
+		app.setThirdPartyApplicationDescription("Test Third Party");
+		app.setScope(new java.util.HashSet<>(java.util.Arrays.asList(scopes)));
+		return app;
+	}
+
+	private static UsagePointEntity usagePoint(UUID id, ServiceCategory category) {
+		UsagePointEntity up = new UsagePointEntity();
+		up.setId(id);
+		up.setServiceCategory(category);
+		return up;
+	}
+
+	private static MessageSource staticMessages() {
+		StaticMessageSource src = new StaticMessageSource();
+		src.setUseCodeAsDefaultMessage(true);
+		return src;
+	}
+}


### PR DESCRIPTION
## Summary

Builds the customer-facing OAuth2 consent screen that PR C3's AS-side `consentPage()` will redirect to. The screen renders exactly what the third party requested — driven entirely by the FB catalog from PR A — and accepts per-FB granular consent decisions (GDPR-style opt-in for sensitive PII categories).

Driven by the XSLT conformance reference at `D:\Dropbox\gbwebsites\dmdvalidator.greenbuttonalliance.org\conformance` (see issue #141 for the full per-FB mapping table).

## What's in this PR

### `FunctionBlock` role helpers (`openespi-common.scope`)

Four new predicates classify each FB by its consent-UI role:

| Predicate | FBs | Screen treatment |
|---|---|---|
| `isImplicitBase()` | 1, 4, 51 | Always implicit; never customer-selectable; footer note only |
| `isCommodityProfile()` | 5, 6, 7, 8, 9, 10, 11, 29 | Drives the commodity sections; profile within commodity is display-only |
| `isDataShapeModifier()` | 12, 15, 16, 17, 27, 28 | Display-only "this app will receive" modifier under each commodity |
| `isPiiSelectable()` | 54–62 | Individually toggleable consent checkbox, default-unchecked |

Both instance and static `(int id)` forms for use with raw FB integers from `EspiScope`. **Behavior on the enum; localized text in the i18n bundle.**

### i18n bundle (`messages.properties`)

~30 keys: `fb.NN.label` + `fb.NN.description` per FB, `commodity.*` section titles, `screen.*` UI strings, `error.*` page strings. English-only for the sandbox; production deployments drop locale-specific overrides. Spring Boot's default `MessageSource` auto-loads it; Thymeleaf `th:text="#{key}"` picks it up natively.

### `SignedHandoff.Return.approvedScope`

Additive field carrying the customer's effective scope (subset of the originally-requested scope, narrowed by the customer's checkbox decisions). The AS mints the access token with this scope, **not the original** — so the TP receives exactly what the customer agreed to. **Codec version stays at 1**: purely additive, old readers see null.

### Authorization Screen (`openespi-datacustodian.web.authorize`)

- **`AuthorizeScreenController`** mounted at `/oauth/authorize-screen`
  - **GET** — decodes + verifies the AS-issued outbound handoff (PR C1 codec), consumes the nonce (single-use replay protection), validates the granted scope is a subset of the TP's registered `ApplicationInformation.scope` (defense in depth; AS is supposed to enforce this at `/authorize`, DC re-verifies), builds the view model, renders `authorize-screen.html`.
  - **POST** — re-verifies the handoff (round-tripped through the form), computes the effective `approvedScope` from the customer's checkbox decisions, builds a `SignedHandoff.Return`, redirects user-agent to `outbound.returnUrl` with the signed return token.
- **`AuthorizeScreenService`** — pure business logic so the FB-subset check and scope-narrowing computation are unit-testable without Spring web context. Implements per-commodity grouping, per-FB PII consent, and the implicit-base auto-inclusion rule (FB 1+4 always present when any commodity remains in the approved scope; FB 51 always present when any PII remains).
- **`AuthorizeScreenViewModel`** — immutable record + nested `CommoditySection`, `UsagePointChoice`, `PiiOption` sub-records. All strings pre-localized in the service.
- **`@ExceptionHandler(InvalidHandoffException)`** — uniform 400 + internal log. Catches ALL handoff failure modes (bad signature, expired, replayed nonce, unknown `client_id`, scope escalation) and returns the existing `templates/error/400.html`. Internal log captures the specific sub-cause for security audit; external response reveals **nothing** about which check failed (don't give attackers an oracle). HTTP 400, not 401/403; no redirect; no echo of attacker-controlled input. Per OWASP guidance.

### `authorize-screen.html` — Bootstrap 5 + Thymeleaf

- **Energy-data section**: one commodity sub-section per `ServiceKind` requested. Customer toggles individual usage points (default-checked — TP explicitly requested the commodity). Profile labels (e.g. "Hourly delivered", "Solar export") and data-shape labels (e.g. "Billing-period summaries", "Power quality") render as display-only "this application will receive" bullets.
- **Personal information section**: one checkbox per PII FB in the requested scope, **default-unchecked**, with the XSLT-verified label + description.
- **Footer note for implicit-base FBs.**
- **Allow / Deny submit buttons**; "Allow with no selections" falls back to deny semantics (`consent=deny`, `approvedScope=null`).
- CSRF token auto-injected by `th:action`; signed handoff round-tripped via hidden field.

## Architectural decisions (recap)

1. **Per-FB consent for PII**, not a single "share PII" checkbox — each PII FB exposes a distinct `cust:*` resource family in the response (XSLT-verified), so consent must be individually toggleable.
2. **Effective scope narrowed by customer choices** — the customer's checkbox decisions can produce a scope strictly narrower than what the TP requested. AS mints the token with the narrowed scope.
3. **Implicit-base FBs are auto-included by outcome**, not preserved from input. The TP might request `FB=4_54` without FB 51; DC adds it because the customer-feed response can't be well-formed without it.
4. **Defense-in-depth scope validation** — even though the AS is supposed to enforce subset-of-registered at `/authorize`, the DC re-verifies. Catches AS bugs, AS compromise, stale registration.
5. **Uniform 400 for all handoff failures** — internal log records the specific cause; external response reveals nothing. Don't give attackers a probe oracle.
6. **Behavior on enum, labels in i18n bundle** — canonical Spring separation; production utilities can override labels without touching Java.

## Test plan

- [x] `FunctionBlockRoleHelpersTest` — **35 parameterized tests** covering all 17 active screen-relevant FBs + representative non-screen and unknown/deprecated FBs.
- [x] `AuthorizeScreenServiceTest` — **13 unit tests** (Mockito + StaticMessageSource): client+scope validation passes for registered subset; rejects unknown client_id; rejects scope escalation; commodity grouping; PII per-FB rendering; scope-narrowing for commodity / PII / mixed / deny cases; implicit-base auto-inclusion.
- [x] `AuthorizeScreenControllerTest` — **8 MockMvc `@SpringBootTest` cases**: invalid handoff (5 sub-causes) all → 400; happy GET renders form with TP name + CSRF + handoff hidden field; POST allow → 302 with signed Return handoff carrying narrowed `approvedScope`; POST deny → 302 with `consent=deny`; POST allow with nothing checked → falls back to deny.
- [x] `openespi-common` full suite: **901 / 901 pass** (was 866; +35 from `FunctionBlockRoleHelpersTest`).
- [x] `openespi-datacustodian` full suite: **139 / 139 pass, 0 skipped** (was 118; +21 from new authorize tests).
- [ ] CI: 3-DB integration tests (MySQL / PostgreSQL / H2 via TestContainers).
- [ ] CI: Security vulnerability scan + SonarCloud.

## Refs

- Foundation for PR C3 (AS-side delegation: `loginPage()` and `consentPage()` URLs pointing here).
- Builds on PR A (#136), PR B1 (#137), PR B2 (#139), PR C1 (#140), PR C2a (#142).
- XSLT mapping reference: #141.
- Lifecycle policy tracked in #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)