### PR TITLE
feat(#148): Phase 2.0 auth-code-flow orchestration integration test (closes #122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
         # compile, matching the pattern used by the unit-test steps above.
         run: mvn verify -Pintegration-tests -pl openespi-common,openespi-datacustodian,openespi-thirdparty -am
 
+      - name: Run integration tests - openespi-authserver (TestContainers, tagged)
+        # The authserver module's UNIT tests are pre-existing-broken on the H2 local/test profiles
+        # and stay excluded from CI (see the commented full-module step above). This runs ONLY the
+        # Docker-backed integration tests tagged @Tag("testcontainers-it"): the MySQL schema/client
+        # suite and the Phase 2.0 auth-code-flow orchestration test (#148), against a real MySQL via
+        # Testcontainers. -Dgroups selects by tag, so the broken unit tests are not executed.
+        run: mvn test -pl openespi-authserver -am -Dgroups=testcontainers-it -DfailIfNoTests=false
+
       # JaCoCo reports are automatically generated during test phase (configured in root pom.xml)
 
       - name: Upload test results

--- a/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/config/AuthorizationServerConfig.java
+++ b/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/config/AuthorizationServerConfig.java
@@ -299,6 +299,12 @@ public class AuthorizationServerConfig {
                     .build())
                 .clientSettings(ClientSettings.builder()
                     .requireAuthorizationConsent(true)
+                    // ESPI does not support PKCE. Spring Authorization Server 7.x requires
+                    // code_challenge for the authorization_code grant unless requireProofKey is
+                    // explicitly false, so the ESPI customer flow (which sends no code_challenge)
+                    // fails with "OAuth 2.0 Parameter: code_challenge" without this. Surfaced by the
+                    // Phase 2.0 end-to-end orchestration test (#148).
+                    .requireProofKey(false)
                     .build())
                 .build();
 

--- a/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/AbstractAuthserverIntegrationTest.java
+++ b/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/AbstractAuthserverIntegrationTest.java
@@ -51,15 +51,17 @@ import org.testcontainers.containers.MySQLContainer;
 public abstract class AbstractAuthserverIntegrationTest {
 
     /**
-     * Singleton container: started once, never stopped explicitly. Ryuk (Testcontainers' reaper)
-     * tears it down when the JVM exits. {@code withReuse(true)} additionally lets it survive across
-     * local runs when the developer has enabled container reuse, shaving startup off the inner loop.
+     * Singleton container: started once per JVM in the static initializer, never stopped explicitly
+     * (Ryuk, Testcontainers' reaper, tears it down at JVM exit). Deliberately NOT {@code withReuse}:
+     * the AS seeds its default clients at context startup with insert-if-absent semantics, so a
+     * container surviving across runs would carry stale seed rows and silently mask seed-definition
+     * changes (e.g. a client's {@code requireProofKey}). A fresh container per run keeps seed-dependent
+     * assertions deterministic in both CI and the local inner loop.
      */
     protected static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
             .withDatabaseName("oauth2_authserver")
             .withUsername("test_user")
-            .withPassword("test_password")
-            .withReuse(true);
+            .withPassword("test_password");
 
     static {
         MYSQL.start();

--- a/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/AbstractAuthserverIntegrationTest.java
+++ b/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/AbstractAuthserverIntegrationTest.java
@@ -17,6 +17,7 @@
 package org.greenbuttonalliance.espi.authserver.integration;
 
 import org.greenbuttonalliance.espi.authserver.AuthorizationServerApplication;
+import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.ActiveProfiles;
@@ -45,6 +46,9 @@ import org.testcontainers.containers.MySQLContainer;
  * and Flyway wiring are inherited. The {@code testcontainers} Spring profile supplies the rest of the
  * AS test configuration (see {@code application-testcontainers.yml}).</p>
  */
+// Tagged so CI can run ONLY the Docker-backed integration tests (-Dgroups=testcontainers-it),
+// excluding the AS module's pre-existing broken H2-profile unit tests. Inherited by subclasses.
+@Tag("testcontainers-it")
 @SpringBootTest(classes = AuthorizationServerApplication.class)
 @AutoConfigureMockMvc
 @ActiveProfiles("testcontainers")

--- a/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/AuthCodeFlowOrchestrationIntegrationTest.java
+++ b/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/AuthCodeFlowOrchestrationIntegrationTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2025 Green Button Alliance, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.greenbuttonalliance.espi.authserver.integration;
+
+import org.greenbuttonalliance.espi.authserver.backchannel.BackchannelRequest;
+import org.greenbuttonalliance.espi.authserver.backchannel.BackchannelResponse;
+import org.greenbuttonalliance.espi.authserver.backchannel.DataCustodianBackchannelClient;
+import org.greenbuttonalliance.espi.authserver.web.delegate.DelegationStateService;
+import org.greenbuttonalliance.espi.handoff.SignedHandoff;
+import org.greenbuttonalliance.espi.handoff.SignedHandoffCodec;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Phase 2.0 end-to-end orchestration test (issue #148, closes #122).
+ *
+ * <p>Drives the AS-side half of the ESPI customer OAuth2 authorization-code flow through a real
+ * Spring Authorization Server context against a Testcontainers MySQL, with only the Data Custodian
+ * back-channel mocked. It simulates the customer's return from DC (a signed Return handoff) and
+ * verifies the AS:</p>
+ * <ol>
+ *   <li>accepts the return handoff at {@code /oauth2/authorize/continue}, authenticates the
+ *       customer, seeds consent, and resumes the flow;</li>
+ *   <li>mints an authorization code at {@code /oauth2/authorize} (no second delegation round);</li>
+ *   <li>at {@code /oauth2/token}, calls the DC back-channel (mocked) and augments the opaque
+ *       token response with the canonical ESPI URIs (the C4 augmentation).</li>
+ * </ol>
+ *
+ * <p>The flow is exercised with a single-term ESPI scope ({@code FB_1}) registered on a test client
+ * created per-run, so the orchestration is verified deterministically without depending on the
+ * seeded {@code third_party} client's multi-term scope.</p>
+ */
+@DisplayName("Phase 2.0 auth-code-flow orchestration (AS-side, DC back-channel mocked)")
+class AuthCodeFlowOrchestrationIntegrationTest extends AbstractAuthserverIntegrationTest {
+
+	private static final String REDIRECT_URI = "https://tp.example/cb";
+	private static final String SCOPE = "FB_1";
+	private static final String CUSTOMER_ID = "42";
+	private static final String CUSTOMER_RESOURCE_URI = "https://dc.example/RetailCustomer/42";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private RegisteredClientRepository registeredClientRepository;
+
+	@Autowired
+	private DelegationStateService delegationStateService;
+
+	@Autowired
+	private SignedHandoffCodec codec;
+
+	@MockitoBean
+	private DataCustodianBackchannelClient backchannelClient;
+
+	@Test
+	@DisplayName("return handoff -> code -> token, token response augmented with back-channel URIs")
+	void fullAuthCodeFlowAugmentsTokenResponse() throws Exception {
+		// Unique identifiers so the test is safe under singleton-container reuse across runs.
+		String suffix = UUID.randomUUID().toString().substring(0, 8);
+		String clientId = "pr-d-tp-" + suffix;
+		String clientSecret = "pr-d-secret-" + suffix;
+		String correlationId = "corr-" + suffix;
+		UUID selectedUsagePoint = UUID.randomUUID();
+
+		RegisteredClient testClient = RegisteredClient.withId(UUID.randomUUID().toString())
+				.clientId(clientId)
+				.clientName("PR-D Test ThirdParty")
+				.clientSecret("{noop}" + clientSecret)
+				.clientIdIssuedAt(Instant.now())
+				.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+				.redirectUri(REDIRECT_URI)
+				.scope(SCOPE)
+				.clientSettings(ClientSettings.builder()
+						.requireAuthorizationConsent(true)
+						.requireProofKey(false) // ESPI does not use PKCE
+						.build())
+				.tokenSettings(TokenSettings.builder()
+						.accessTokenFormat(OAuth2TokenFormat.REFERENCE) // ESPI: opaque
+						.accessTokenTimeToLive(Duration.ofMinutes(360))
+						.build())
+				.build();
+		registeredClientRepository.save(testClient);
+
+		// The outbound leg already happened in real life; seed the delegation state it would have left.
+		delegationStateService.save(correlationId, clientId, REDIRECT_URI, "tp-state-" + suffix);
+
+		// What the DC back-channel will return once the token is minted.
+		UUID authorizationId = UUID.randomUUID();
+		UUID resourceSubscriptionId = UUID.randomUUID();
+		UUID customerSubscriptionId = UUID.randomUUID();
+		String resourceUri = "https://dc.example/Subscription/" + resourceSubscriptionId;
+		String authorizationUri = "https://dc.example/Authorization/" + authorizationId;
+		String customerResourceUri = "https://dc.example/RetailCustomer/42/Customer/" + customerSubscriptionId;
+		when(backchannelClient.provision(any())).thenReturn(new BackchannelResponse(
+				authorizationId, resourceSubscriptionId, customerSubscriptionId,
+				resourceUri, authorizationUri, customerResourceUri));
+
+		// Mint a valid signed Return handoff (same signing key as the context, via the autowired codec).
+		Instant now = Instant.now();
+		String handoff = codec.encode(SignedHandoff.Return.of(
+				correlationId, now, now.plusSeconds(300),
+				UUID.randomUUID().toString().replace("-", ""), // single-use nonce
+				CUSTOMER_ID,
+				List.of(selectedUsagePoint),
+				CUSTOMER_RESOURCE_URI,
+				SignedHandoff.Return.CONSENT_ALLOW,
+				SCOPE));
+
+		// 1) Return from DC: /oauth2/authorize/continue -> 302 to /oauth2/authorize. Keep the session.
+		MvcResult continueResult = mockMvc.perform(get("/oauth2/authorize/continue").param("handoff", handoff))
+				.andExpect(status().is3xxRedirection())
+				.andExpect(header().string("Location",
+						org.hamcrest.Matchers.startsWith("/oauth2/authorize")))
+				.andReturn();
+		MockHttpSession session = (MockHttpSession) continueResult.getRequest().getSession(false);
+		assertThat(session).isNotNull();
+		String authorizeUrl = continueResult.getResponse().getHeader("Location");
+
+		// 2) Resume /oauth2/authorize on the authenticated, consent-seeded session -> 302 to TP with code.
+		MvcResult authorizeResult = mockMvc.perform(get(authorizeUrl).session(session))
+				.andExpect(status().is3xxRedirection())
+				.andReturn();
+		String location = authorizeResult.getResponse().getHeader("Location");
+		assertThat(location)
+				.as("authorize should redirect to the TP callback carrying an authorization code")
+				.startsWith(REDIRECT_URI)
+				.contains("code=");
+		String code = extractQueryParam(location, "code");
+		assertThat(code).isNotBlank();
+
+		// 3) Exchange the code at /oauth2/token -> back-channel fires, response augmented with URIs.
+		mockMvc.perform(post("/oauth2/token")
+						.with(httpBasic(clientId, clientSecret))
+						.param("grant_type", "authorization_code")
+						.param("code", code)
+						.param("redirect_uri", REDIRECT_URI))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.access_token").isNotEmpty())
+				.andExpect(jsonPath("$.token_type").value("Bearer"))
+				.andExpect(jsonPath("$.resourceURI").value(resourceUri))
+				.andExpect(jsonPath("$.authorizationURI").value(authorizationUri))
+				.andExpect(jsonPath("$.customerResourceURI").value(customerResourceUri))
+				.andExpect(jsonPath("$.authorization_id").value(authorizationId.toString()))
+				.andExpect(jsonPath("$.resource_subscription_id").value(resourceSubscriptionId.toString()))
+				.andExpect(jsonPath("$.customer_subscription_id").value(customerSubscriptionId.toString()));
+
+		// The back-channel was called with the customer-selection context carried through the flow.
+		ArgumentCaptor<BackchannelRequest> captor = ArgumentCaptor.forClass(BackchannelRequest.class);
+		verify(backchannelClient).provision(captor.capture());
+		BackchannelRequest sent = captor.getValue();
+		assertThat(sent.correlationId()).isEqualTo(correlationId);
+		assertThat(sent.clientId()).isEqualTo(clientId);
+		assertThat(sent.grantedScope()).isEqualTo(SCOPE);
+		assertThat(sent.retailCustomerId()).isEqualTo(42L);
+		assertThat(sent.selectedUsagePointIds()).containsExactly(selectedUsagePoint);
+		assertThat(sent.customerResourceUri()).isEqualTo(CUSTOMER_RESOURCE_URI);
+	}
+
+	@Test
+	@DisplayName("seeded third_party client has PKCE disabled (ESPI does not support PKCE)")
+	void seededThirdPartyClientDoesNotRequireProofKey() {
+		RegisteredClient thirdParty = registeredClientRepository.findByClientId("third_party");
+		assertThat(thirdParty)
+				.as("default third_party client must be seeded")
+				.isNotNull();
+		assertThat(thirdParty.getClientSettings().isRequireProofKey())
+				.as("ESPI does not support PKCE; the customer-flow client must not require code_challenge")
+				.isFalse();
+	}
+
+	private static String extractQueryParam(String url, String name) {
+		return org.springframework.web.util.UriComponentsBuilder.fromUriString(url)
+				.build().getQueryParams().getFirst(name);
+	}
+}

--- a/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/MySqlTestcontainersIntegrationTest.java
+++ b/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/MySqlTestcontainersIntegrationTest.java
@@ -25,6 +25,7 @@ import org.springframework.security.oauth2.server.authorization.client.JdbcRegis
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -60,6 +61,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @version 1.0.0
  * @since Spring Boot 3.5
  */
+@Tag("testcontainers-it") // CI runs the Docker-backed AS integration tests via -Dgroups=testcontainers-it
 @SpringBootTest
 @Testcontainers
 @ActiveProfiles("testcontainers")


### PR DESCRIPTION
Closes #148. Closes #122.

## What

The Phase 2.0 end-to-end integration test that closes the verification gap for the ESPI customer OAuth2 flow (#122). It drives the **AS-side** authorization-code flow through a real Spring Authorization Server context against Testcontainers MySQL, with only the Data Custodian back-channel mocked:

1. mints a signed **Return handoff** (as DC would after customer login + per-FB consent);
2. `POST`/`GET` `/oauth2/authorize/continue` → AS authenticates the customer, seeds consent, resumes;
3. `/oauth2/authorize` → authorization **code** at the TP `redirect_uri`;
4. `/oauth2/token` → asserts the opaque token response is **augmented** with the six canonical ESPI URIs/ids from the (mocked) back-channel — `resourceURI`, `authorizationURI`, `customerResourceURI`, `authorization_id`, `resource_subscription_id`, `customer_subscription_id` (the C4 augmentation);
5. verifies the back-channel was called with the carried customer-selection context (correlation id, client, granted scope, retail customer id, usage points).

## Real bug caught and fixed: ESPI client required PKCE

The seeded `third_party` customer-flow client did not set `requireProofKey(false)`. Spring Authorization Server 7.x (OAuth 2.1 lineage) requires `code_challenge` for the authorization_code grant unless proof key is explicitly disabled — so the ESPI customer flow (which sends **no** `code_challenge`, because **ESPI does not support PKCE**) failed with `[invalid_request] OAuth 2.0 Parameter: code_challenge`. Fixed by `.requireProofKey(false)` on the client, guarded by a focused regression test. Never caught before because AS tests don't run in CI.

> ⚠️ **Deployment note:** AS seeds default clients insert-if-absent, so this fix only reaches a **fresh** DB. An already-seeded `third_party` keeps the stale row and still rejects the flow until re-seeded or updated. Tracked by #154.

## CI gating

AS tests have never run in CI (the module is ~50% red on the pre-existing H2 `local`/`test` profiles). Rather than enable the whole module (would go red on unrelated rot) or rename to `*IT`/Failsafe (needs the Mockito agent re-wired onto Failsafe for `@MockitoBean`), the two Docker-backed integration tests are tagged `@Tag("testcontainers-it")` and a CI step runs only that group:

```
mvn test -pl openespi-authserver -am -Dgroups=testcontainers-it -DfailIfNoTests=false
```

Runs exactly 20 tests (MySQL schema/client suite + the orchestration test); excludes the broken unit tests by construction. This is the first time any AS test runs in CI.

## Also

- Dropped `withReuse(true)` from `AbstractAuthserverIntegrationTest`: insert-if-absent seeding + a reused container carried stale seed rows and masked the very `requireProofKey` fix during development. Fresh container per run keeps seed-dependent assertions deterministic.

## Verification

`mvn test -pl openespi-authserver -Dgroups=testcontainers-it` → **20/20 green** locally against Docker `mysql:8.0`.

## Follow-ups filed
- #154 — AS default-client seeding is insert-only; seed-definition changes (this PKCE fix, #149's clientNames) don't reach existing DBs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)