### PR TITLE
fix(#157): enforce DC resources with ESPI 4.0 FB scopes (scrap legacy vocabulary)

### DIFF
--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/config/EspiScopeOpaqueTokenIntrospector.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/config/EspiScopeOpaqueTokenIntrospector.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *        Copyright (c) 2025 Green Button Alliance, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.greenbuttonalliance.espi.datacustodian.config;
+
+import org.greenbuttonalliance.espi.common.scope.EspiScope;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Wraps the stock {@link OpaqueTokenIntrospector} and translates the introspected token's ESPI
+ * scope into ESPI Function-Block authorities the Data Custodian enforces on its resource endpoints.
+ *
+ * <p>The Authorization Server issues the ESPI 4.0 scope grammar
+ * ({@code FB=4_5_15;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13}). Spring's stock
+ * introspector would map that whole string to a single opaque authority
+ * ({@code SCOPE_FB=4_5_15;...}), which matches none of the DC's endpoint rules — so a real customer
+ * token would 403 on every resource (issue #157). This introspector instead parses the scope via
+ * {@link EspiScope} and emits one {@code FB_<n>} authority per granted function block (e.g.
+ * {@code FB_4}, {@code FB_5}, {@code FB_15}).</p>
+ *
+ * <p>Non-FB scopes — the admin/OIDC scopes such as {@code DataCustodian_Admin_Access},
+ * {@code ThirdParty_Admin_Access}, {@code openid}, {@code profile} — are passed through with the
+ * conventional {@code SCOPE_} prefix so existing admin endpoint rules keep working.</p>
+ *
+ * <p>This replaces the contractor's non-ESPI {@code SCOPE_FB_<n>_READ/WRITE_3rd_party} vocabulary,
+ * which had no relationship to the scopes the AS actually issues.</p>
+ */
+public final class EspiScopeOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
+
+	private final OpaqueTokenIntrospector delegate;
+
+	public EspiScopeOpaqueTokenIntrospector(OpaqueTokenIntrospector delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public OAuth2AuthenticatedPrincipal introspect(String token) {
+		OAuth2AuthenticatedPrincipal principal = delegate.introspect(token);
+		Set<GrantedAuthority> authorities = new LinkedHashSet<>();
+		for (String scope : scopesOf(principal)) {
+			EspiScope parsed = EspiScope.parse(scope);
+			if (parsed.functionBlocks().isEmpty()) {
+				// admin / OIDC / any non-ESPI scope — keep the stock SCOPE_ authority.
+				authorities.add(new SimpleGrantedAuthority("SCOPE_" + scope));
+			} else {
+				// ESPI FB scope — one authority per granted function block.
+				for (Integer fb : parsed.functionBlocks()) {
+					authorities.add(new SimpleGrantedAuthority("FB_" + fb));
+				}
+			}
+		}
+		return new DefaultOAuth2AuthenticatedPrincipal(principal.getName(), principal.getAttributes(), authorities);
+	}
+
+	/**
+	 * The introspected {@code scope} claim. Spring's stock introspector stores it as a
+	 * {@code List<String>} split on spaces; tolerate a raw {@code String} as well.
+	 */
+	private static Collection<String> scopesOf(OAuth2AuthenticatedPrincipal principal) {
+		Object scope = principal.getAttribute("scope");
+		if (scope instanceof Collection<?> collection) {
+			List<String> out = new ArrayList<>(collection.size());
+			for (Object o : collection) {
+				if (o != null) {
+					out.add(o.toString());
+				}
+			}
+			return out;
+		}
+		if (scope instanceof String s && !s.isBlank()) {
+			return Arrays.asList(s.trim().split("\\s+"));
+		}
+		return List.of();
+	}
+}

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/config/SecurityConfiguration.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/config/SecurityConfiguration.java
@@ -19,11 +19,16 @@
 
 package org.greenbuttonalliance.espi.datacustodian.config;
 
+import org.greenbuttonalliance.espi.common.scope.FunctionBlock;
+import org.greenbuttonalliance.espi.common.scope.FunctionBlockCategory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authorization.AuthorityAuthorizationManager;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationManagers;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -33,12 +38,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Security configuration for the OpenESPI Data Custodian Resource Server.
@@ -75,20 +82,61 @@ public class SecurityConfiguration {
      */
     @Bean
     @Order(1)
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   OpaqueTokenIntrospector introspector) throws Exception {
+        // ESPI 4.0 Function-Block authorization managers. Authorities are minted by
+        // EspiScopeOpaqueTokenIntrospector: FB_<n> per granted function block, plus SCOPE_<scope>
+        // for admin/OIDC scopes. (Replaces the contractor's non-ESPI SCOPE_FB_n_READ/WRITE_3rd_party.)
+        AuthorizationManager<RequestAuthorizationContext> admin =
+                AuthorityAuthorizationManager.hasAuthority("SCOPE_DataCustodian_Admin_Access");
+        AuthorizationManager<RequestAuthorizationContext> adminOrTpAdmin =
+                AuthorityAuthorizationManager.hasAnyAuthority(
+                        "SCOPE_DataCustodian_Admin_Access", "SCOPE_ThirdParty_Admin_Access");
+
+        // Usage data (UsagePoint + its interval data: MeterReading, ReadingType, IntervalBlock,
+        // LocalTimeParameters, Batch). ESPI: base FB_4 (Interval Metering) AND at least one
+        // commodity FB (electricity/gas/water/temperature) — or DataCustodian admin.
+        AuthorizationManager<RequestAuthorizationContext> fb4 =
+                AuthorityAuthorizationManager.hasAuthority("FB_4");
+        AuthorizationManager<RequestAuthorizationContext> commodity =
+                AuthorityAuthorizationManager.hasAnyAuthority(commodityAuthorities());
+        AuthorizationManager<RequestAuthorizationContext> usageData =
+                AuthorizationManagers.anyOf(admin, AuthorizationManagers.allOf(fb4, commodity));
+
+        // Usage summaries (data-shape FBs) and power-quality summary (FB_17).
+        AuthorizationManager<RequestAuthorizationContext> usageSummary =
+                AuthorizationManagers.anyOf(admin,
+                        AuthorityAuthorizationManager.hasAnyAuthority("FB_15", "FB_16", "FB_27", "FB_28"));
+        AuthorizationManager<RequestAuthorizationContext> powerQuality =
+                AuthorizationManagers.anyOf(admin, AuthorityAuthorizationManager.hasAuthority("FB_17"));
+
+        // Customer / PII resources — least-privilege per the ESPI Customer-PII catalog: the base
+        // Connect-My-Data customer FB (FB_53) AND the resource-specific FB, or admin. FB→resource
+        // mapping is authoritative from the DMD-validator conformance XSLTs (FB_NN.xsl). Note: FB_55
+        // (Address) gates a field embedded in Customer, not an endpoint — deferred to response-shaping.
+        AuthorizationManager<RequestAuthorizationContext> customerBase = piiGate(admin, "FB_54");   // Customer
+        AuthorizationManager<RequestAuthorizationContext> customerAccount = piiGate(admin, "FB_56"); // billing
+        AuthorizationManager<RequestAuthorizationContext> customerAgreement = piiGate(admin, "FB_57");
+        AuthorizationManager<RequestAuthorizationContext> serviceLocation = piiGate(admin, "FB_58");
+        AuthorizationManager<RequestAuthorizationContext> serviceSupplier = piiGate(admin, "FB_59");
+        AuthorizationManager<RequestAuthorizationContext> meter = piiGate(admin, "FB_60");
+        AuthorizationManager<RequestAuthorizationContext> endDevice = piiGate(admin, "FB_61");
+        AuthorizationManager<RequestAuthorizationContext> programMapping = piiGate(admin, "FB_62");
+
         return http
             // Disable CSRF for API endpoints
             .csrf(AbstractHttpConfigurer::disable)
-            
+
             // Enable CORS
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-            
+
             // Configure session management (stateless for OAuth2)
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
-            
-            // Configure authorization rules
+
+            // Configure authorization rules. ESPI customer FB scopes are READ-ONLY; every write is
+            // admin-gated (see the blanket write rule below).
             .authorizeHttpRequests(authz -> authz
                 // Public endpoints
                 .requestMatchers(
@@ -99,105 +147,81 @@ public class SecurityConfiguration {
                     "/swagger-ui.html",
                     "/h2-console/**"
                 ).permitAll()
-                
-                // ESPI root resource endpoints (require authentication)
+
+                // --- Admin-only resources (OAuth2 metadata, not energy/PII) ---
                 .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/ApplicationInformation/**")
-                    .hasAnyAuthority("SCOPE_DataCustodian_Admin_Access", "SCOPE_ThirdParty_Admin_Access")
-                
-                // /Authorization is admin (DataCustodian admin) or client (ThirdParty admin via
-                // client_credentials) only — never reachable with a customer FB-scoped token,
-                // because the resource exposes OAuth2 authorization metadata, not energy/PII data.
+                    .access(adminOrTpAdmin)
                 .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/Authorization/**")
-                    .hasAnyAuthority(
-                        "SCOPE_DataCustodian_Admin_Access",
-                        "SCOPE_ThirdParty_Admin_Access"
-                    )
-                
-                // ESPI Usage Point endpoints
-                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/UsagePoint/**")
-                    .hasAnyAuthority(
-                        "SCOPE_FB_15_READ_3rd_party", 
-                        "SCOPE_FB_16_READ_3rd_party", 
-                        "SCOPE_FB_36_READ_3rd_party",
-                        "SCOPE_DataCustodian_Admin_Access"
-                    )
-                
-                .requestMatchers(HttpMethod.POST, "/espi/1_1/resource/UsagePoint/**")
-                    .hasAnyAuthority(
-                        "SCOPE_FB_15_WRITE_3rd_party", 
-                        "SCOPE_FB_16_WRITE_3rd_party", 
-                        "SCOPE_FB_36_WRITE_3rd_party",
-                        "SCOPE_DataCustodian_Admin_Access"
-                    )
-                
-                // ESPI SubscriptionEntity-based endpoints
-                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/Subscription/*/UsagePoint/**")
-                    .hasAnyAuthority(
-                        "SCOPE_FB_15_READ_3rd_party", 
-                        "SCOPE_FB_16_READ_3rd_party", 
-                        "SCOPE_FB_36_READ_3rd_party"
-                    )
-                
-                .requestMatchers(HttpMethod.POST, "/espi/1_1/resource/Subscription/*/UsagePoint/**")
-                    .hasAnyAuthority(
-                        "SCOPE_FB_15_WRITE_3rd_party", 
-                        "SCOPE_FB_16_WRITE_3rd_party", 
-                        "SCOPE_FB_36_WRITE_3rd_party"
-                    )
-                
-                // ESPI Meter Reading endpoints
-                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/MeterReading/**")
-                    .hasAnyAuthority(
-                        "SCOPE_FB_15_READ_3rd_party", 
-                        "SCOPE_FB_16_READ_3rd_party", 
-                        "SCOPE_FB_36_READ_3rd_party",
-                        "SCOPE_DataCustodian_Admin_Access"
-                    )
-                
-                .requestMatchers(HttpMethod.POST, "/espi/1_1/resource/MeterReading/**")
-                    .hasAnyAuthority(
-                        "SCOPE_FB_15_WRITE_3rd_party", 
-                        "SCOPE_FB_16_WRITE_3rd_party", 
-                        "SCOPE_FB_36_WRITE_3rd_party",
-                        "SCOPE_DataCustodian_Admin_Access"
-                    )
-                
-                // ESPI Interval Reading endpoints
-                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/IntervalReading/**")
-                    .hasAnyAuthority(
-                        "SCOPE_FB_15_READ_3rd_party", 
-                        "SCOPE_FB_16_READ_3rd_party", 
-                        "SCOPE_FB_36_READ_3rd_party",
-                        "SCOPE_DataCustodian_Admin_Access"
-                    )
-                
-                // ESPI Batch endpoints
-                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/Batch/**")
-                    .hasAnyAuthority(
-                        "SCOPE_FB_15_READ_3rd_party", 
-                        "SCOPE_FB_16_READ_3rd_party", 
-                        "SCOPE_FB_36_READ_3rd_party",
-                        "SCOPE_DataCustodian_Admin_Access"
-                    )
-                
+                    .access(adminOrTpAdmin)
+
+                // --- Usage summaries (GET) : data-shape FBs, or admin. The summary/PQ leaf rules
+                //     (including Subscription-/RetailCustomer-scoped XPath forms) MUST precede the
+                //     broad usage-data rule, so a summary reached via /Subscription/.../UsageSummary is
+                //     gated by its own FB rather than FB_4+commodity. ---
+                .requestMatchers(HttpMethod.GET,
+                    "/espi/1_1/resource/UsageSummary/**",
+                    "/espi/1_1/resource/ElectricPowerUsageSummary/**",
+                    "/espi/1_1/resource/Subscription/*/UsagePoint/*/UsageSummary/**",
+                    "/espi/1_1/resource/Subscription/*/UsagePoint/*/ElectricPowerUsageSummary/**",
+                    "/espi/1_1/resource/RetailCustomer/*/UsagePoint/*/UsageSummary/**",
+                    "/espi/1_1/resource/RetailCustomer/*/UsagePoint/*/ElectricPowerUsageSummary/**")
+                    .access(usageSummary)
+
+                // --- Power-quality summary (GET) : FB_17, or admin ---
+                .requestMatchers(HttpMethod.GET,
+                    "/espi/1_1/resource/ElectricPowerQualitySummary/**",
+                    "/espi/1_1/resource/Subscription/*/UsagePoint/*/ElectricPowerQualitySummary/**",
+                    "/espi/1_1/resource/RetailCustomer/*/UsagePoint/*/ElectricPowerQualitySummary/**")
+                    .access(powerQuality)
+
+                // --- Usage data (GET, read-only) : FB_4 + commodity, or admin ---
+                .requestMatchers(HttpMethod.GET,
+                    "/espi/1_1/resource/UsagePoint/**",
+                    "/espi/1_1/resource/MeterReading/**",
+                    "/espi/1_1/resource/ReadingType/**",
+                    "/espi/1_1/resource/IntervalBlock/**",
+                    "/espi/1_1/resource/IntervalReading/**",
+                    "/espi/1_1/resource/LocalTimeParameter/**",
+                    "/espi/1_1/resource/LocalTimeParameters/**",
+                    "/espi/1_1/resource/Batch/**",
+                    "/espi/1_1/resource/Subscription/**",
+                    "/espi/1_1/resource/RetailCustomer/*/UsagePoint/**")
+                    .access(usageData)
+
+                // --- Customer / PII resources (GET) : FB_53 base + resource-specific FB, or admin ---
+                // ROOT forms are gated 1:1 per the conformance-XSLT FB mapping.
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/CustomerAccount/**").access(customerAccount)
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/CustomerAgreement/**").access(customerAgreement)
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/ServiceSupplier/**").access(serviceSupplier)
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/ServiceLocation/**").access(serviceLocation)
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/Meter/**").access(meter)
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/EndDevice/**").access(endDevice)
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/ProgramDateIdMappings/**").access(programMapping)
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/Customer/**").access(customerBase)
+                // XPath customer subtree: customer-base floor (FB_53+FB_54). Per-leaf XPath gating and
+                // FB_55 (Address, a Customer field) are response-shaping refinements — Phase 2.
+                .requestMatchers(HttpMethod.GET, "/espi/1_1/resource/RetailCustomer/*/Customer/**").access(customerBase)
+
+                // --- All resource writes are admin-only (ESPI third-party access is read-only) ---
+                .requestMatchers(HttpMethod.POST, "/espi/1_1/resource/**").access(admin)
+                .requestMatchers(HttpMethod.PUT, "/espi/1_1/resource/**").access(admin)
+                .requestMatchers(HttpMethod.DELETE, "/espi/1_1/resource/**").access(admin)
+
                 // Admin endpoints
-                .requestMatchers("/admin/**")
-                    .hasAuthority("SCOPE_DataCustodian_Admin_Access")
-                
+                .requestMatchers("/admin/**").access(admin)
+
                 // All other ESPI endpoints require authentication
                 .requestMatchers("/espi/**").authenticated()
-                
+
                 // All other requests require authentication
                 .anyRequest().authenticated()
             )
-            
-            // Configure OAuth2 Resource Server with opaque token introspection
-            // ESPI standard requires opaque tokens, not JWT tokens
+
+            // Configure OAuth2 Resource Server with opaque token introspection.
+            // ESPI standard requires opaque tokens, not JWT. The custom introspector
+            // (EspiScopeOpaqueTokenIntrospector) maps the ESPI FB scope to FB_<n> authorities.
             .oauth2ResourceServer(oauth2 -> oauth2
-                .opaqueToken(opaque -> opaque
-                    .introspectionUri(introspectionUri)
-                    .introspectionClientCredentials(clientId, clientSecret)
-                )
+                .opaqueToken(opaque -> opaque.introspector(introspector))
             )
             
             // Security headers configuration
@@ -228,14 +252,42 @@ public class SecurityConfiguration {
      */
 
     /**
-     * Configures the Opaque Token Introspector to validate tokens against the AuthorizationEntity Server.
+     * Configures the Opaque Token Introspector to validate tokens against the Authorization Server,
+     * wrapped so the ESPI FB scope is translated into FB_&lt;n&gt; authorities the resource rules enforce
+     * (see {@link EspiScopeOpaqueTokenIntrospector}).
      */
     @Bean
     public OpaqueTokenIntrospector introspector() {
-        return  SpringOpaqueTokenIntrospector.withIntrospectionUri(introspectionUri)
+        OpaqueTokenIntrospector delegate = SpringOpaqueTokenIntrospector.withIntrospectionUri(introspectionUri)
                 .clientId(clientId)
                 .clientSecret(clientSecret)
                 .build();
+        return new EspiScopeOpaqueTokenIntrospector(delegate);
+    }
+
+    /**
+     * The {@code FB_<n>} authorities for every commodity Function Block (electricity/gas/water/
+     * temperature), derived from the single ESPI FB catalog in {@link FunctionBlock} so this never
+     * drifts from the spec.
+     */
+    private static String[] commodityAuthorities() {
+        return Stream.of(FunctionBlock.values())
+                .filter(fb -> fb.getCategory() == FunctionBlockCategory.COMMODITY)
+                .map(fb -> "FB_" + fb.getId())
+                .toArray(String[]::new);
+    }
+
+    /**
+     * Customer-PII endpoint gate: {@code admin OR (FB_53 base AND the resource-specific FB)}.
+     * FB_53 (Connect My Data, Retail Customer) is the prerequisite base for any customer/PII access;
+     * the resource FB (54/56/57/58/59/60/61/62) enforces least privilege per the ESPI Customer-PII
+     * catalog (mapping derived from the DMD-validator conformance XSLTs).
+     */
+    private static AuthorizationManager<RequestAuthorizationContext> piiGate(
+            AuthorizationManager<RequestAuthorizationContext> admin, String resourceFb) {
+        AuthorizationManager<RequestAuthorizationContext> base = AuthorityAuthorizationManager.hasAuthority("FB_53");
+        AuthorizationManager<RequestAuthorizationContext> specific = AuthorityAuthorizationManager.hasAuthority(resourceFb);
+        return AuthorizationManagers.anyOf(admin, AuthorizationManagers.allOf(base, specific));
     }
 
 

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerAccountRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerAccountRESTController.java
@@ -37,7 +37,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -80,8 +79,6 @@ public class CustomerAccountRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party')")
     public ResponseEntity<byte[]> getCustomerAccountCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
@@ -114,8 +111,6 @@ public class CustomerAccountRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party')")
     public ResponseEntity<byte[]> getCustomerAccount(
             @Parameter(description = "Unique identifier of the CustomerAccount", required = true)
             @PathVariable UUID customerAccountId) {
@@ -145,8 +140,6 @@ public class CustomerAccountRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_16_WRITE_3rd_party')")
     public ResponseEntity<CustomerAccountDto> createCustomerAccount(@RequestBody CustomerAccountDto dto) {
         CustomerAccountEntity entity = customerAccountMapper.toEntity(dto);
         CustomerAccountEntity savedEntity = customerAccountService.save(entity);
@@ -175,8 +168,6 @@ public class CustomerAccountRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_16_WRITE_3rd_party')")
     public ResponseEntity<CustomerAccountDto> updateCustomerAccount(
             @PathVariable UUID customerAccountId,
             @RequestBody CustomerAccountDto dto) {
@@ -206,8 +197,6 @@ public class CustomerAccountRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_16_WRITE_3rd_party')")
     public ResponseEntity<Void> deleteCustomerAccount(@PathVariable UUID customerAccountId) {
         if (!customerAccountRepository.existsById(customerAccountId)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "CustomerAccount not found for id: " + customerAccountId);

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerRESTController.java
@@ -38,7 +38,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -81,8 +80,6 @@ public class CustomerRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party')")
     public ResponseEntity<byte[]> getCustomerCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
@@ -115,8 +112,6 @@ public class CustomerRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party')")
     public ResponseEntity<byte[]> getCustomer(
             @Parameter(description = "Unique identifier of the Customer", required = true)
             @PathVariable UUID customerId) {
@@ -147,8 +142,6 @@ public class CustomerRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_WRITE_3rd_party')")
     public ResponseEntity<CustomerDto> createCustomer(@Valid @RequestBody CustomerDto customerDto) {
         CustomerEntity entity = customerMapper.toEntity(customerDto);
         CustomerEntity savedEntity = customerService.save(entity);
@@ -178,8 +171,6 @@ public class CustomerRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_WRITE_3rd_party')")
     public ResponseEntity<CustomerDto> updateCustomer(
             @Parameter(description = "Unique identifier of the Customer", required = true)
             @PathVariable UUID customerId,
@@ -209,8 +200,6 @@ public class CustomerRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_WRITE_3rd_party')")
     public ResponseEntity<Void> deleteCustomer(
             @Parameter(description = "Unique identifier of the Customer", required = true)
             @PathVariable UUID customerId) {

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ElectricPowerQualitySummaryRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ElectricPowerQualitySummaryRESTController.java
@@ -36,7 +36,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -82,10 +81,6 @@ public class ElectricPowerQualitySummaryRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getElectricPowerQualitySummaryCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
@@ -119,10 +114,6 @@ public class ElectricPowerQualitySummaryRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getElectricPowerQualitySummary(
             @Parameter(description = "Unique identifier of the ElectricPowerQualitySummary", required = true)
             @PathVariable UUID electricPowerQualitySummaryId) {
@@ -153,9 +144,6 @@ public class ElectricPowerQualitySummaryRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getSubscriptionElectricPowerQualitySummaries(
             @Parameter(description = "Unique identifier of the subscription", required = true)
             @PathVariable UUID subscriptionId,
@@ -194,9 +182,6 @@ public class ElectricPowerQualitySummaryRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getSubscriptionElectricPowerQualitySummary(
             @Parameter(description = "Unique identifier of the subscription", required = true)
             @PathVariable UUID subscriptionId,

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/IntervalBlockRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/IntervalBlockRESTController.java
@@ -35,7 +35,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -75,10 +74,6 @@ public class IntervalBlockRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getIntervalBlockCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
@@ -112,10 +107,6 @@ public class IntervalBlockRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getIntervalBlock(
             @Parameter(description = "Unique identifier of the Interval Block", required = true)
             @PathVariable UUID intervalBlockId,
@@ -147,9 +138,6 @@ public class IntervalBlockRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getSubscriptionIntervalBlocks(
             @Parameter(description = "Unique identifier of the Subscription", required = true)
             @PathVariable UUID subscriptionId,
@@ -186,9 +174,6 @@ public class IntervalBlockRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getSubscriptionIntervalBlock(
             @Parameter(description = "Unique identifier of the Subscription", required = true)
             @PathVariable UUID subscriptionId,

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/MeterReadingController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/MeterReadingController.java
@@ -35,7 +35,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -80,10 +79,6 @@ public class MeterReadingController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getAllMeterReadings(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
@@ -117,10 +112,6 @@ public class MeterReadingController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getMeterReading(
             @Parameter(description = "Unique identifier of the Meter Reading", required = true)
             @PathVariable UUID meterReadingId,

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ReadingTypeRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/ReadingTypeRESTController.java
@@ -35,7 +35,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -78,10 +77,6 @@ public class ReadingTypeRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getReadingTypeCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
@@ -115,10 +110,6 @@ public class ReadingTypeRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getReadingType(
             @Parameter(description = "Unique identifier of the Reading Type", required = true)
             @PathVariable UUID readingTypeId,

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsagePointController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsagePointController.java
@@ -34,7 +34,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -85,10 +84,6 @@ public class UsagePointController {
                     @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
             }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-            "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-            "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-            "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     @GetMapping(value = "/UsagePoint", produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<byte[]> getAllUsagePoints(@RequestParam(defaultValue = "50") int limit,
                                                     @RequestParam(defaultValue = "0") int offset) {
@@ -134,10 +129,6 @@ public class UsagePointController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getUsagePoint(
             @Parameter(description = "Unique identifier of the Usage Point", required = true)
             @PathVariable UUID usagePointId) {
@@ -167,9 +158,6 @@ public class UsagePointController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getSubscriptionUsagePoints(
             @Parameter(description = "Unique identifier of the SubscriptionEntity", required = true)
             @PathVariable UUID subscriptionId,
@@ -206,9 +194,6 @@ public class UsagePointController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getSubscriptionUsagePoint(
             @Parameter(description = "Unique identifier of the SubscriptionEntity", required = true)
             @PathVariable UUID subscriptionId,

--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsageSummaryRESTController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsageSummaryRESTController.java
@@ -35,7 +35,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -79,10 +78,6 @@ public class UsageSummaryRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getUsageSummaryCollection(
             @Parameter(description = "Maximum number of results to return", example = "50")
             @RequestParam(defaultValue = "50") int limit,
@@ -116,10 +111,6 @@ public class UsageSummaryRESTController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient scope")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_DataCustodian_Admin_Access') or " +
-                 "hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getUsageSummary(
             @Parameter(description = "Unique identifier of the Usage Summary", required = true)
             @PathVariable UUID usageSummaryId,
@@ -148,9 +139,6 @@ public class UsageSummaryRESTController {
             @ApiResponse(responseCode = "404", description = "Subscription or Usage Point not found")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getSubscriptionUsageSummaries(
             @Parameter(description = "Unique identifier of the Subscription", required = true)
             @PathVariable UUID subscriptionId,
@@ -186,9 +174,6 @@ public class UsageSummaryRESTController {
             @ApiResponse(responseCode = "404", description = "Usage Summary, Subscription, or Usage Point not found")
         }
     )
-    @PreAuthorize("hasAuthority('SCOPE_FB_15_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_16_READ_3rd_party') or " +
-                 "hasAuthority('SCOPE_FB_36_READ_3rd_party')")
     public ResponseEntity<byte[]> getSubscriptionUsageSummary(
             @Parameter(description = "Unique identifier of the Subscription", required = true)
             @PathVariable UUID subscriptionId,

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/config/EspiScopeOpaqueTokenIntrospectorTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/config/EspiScopeOpaqueTokenIntrospectorTest.java
@@ -1,0 +1,96 @@
+/*
+ *
+ *        Copyright (c) 2025 Green Button Alliance, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.greenbuttonalliance.espi.datacustodian.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link EspiScopeOpaqueTokenIntrospector} — the ESPI-scope → FB-authority
+ * translation that fixes the AS↔DC vocabulary mismatch (#157).
+ */
+@DisplayName("ESPI FB-scope introspector (#157)")
+class EspiScopeOpaqueTokenIntrospectorTest {
+
+	/** A stub delegate that returns a principal whose {@code scope} attribute is the given value. */
+	private static OpaqueTokenIntrospector delegateWithScope(Object scopeAttribute) {
+		return token -> new DefaultOAuth2AuthenticatedPrincipal(
+				"42", Map.of("scope", scopeAttribute, "active", true),
+				AuthorityUtils.NO_AUTHORITIES);
+	}
+
+	private static List<String> authorities(OAuth2AuthenticatedPrincipal p) {
+		return p.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
+	}
+
+	@Test
+	@DisplayName("customer FB scope -> one FB_<n> authority per function block")
+	void customerFbScopeMapsToFbAuthorities() {
+		OpaqueTokenIntrospector introspector = new EspiScopeOpaqueTokenIntrospector(delegateWithScope(
+				List.of("openid", "profile",
+						"FB=4_5_15;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13")));
+
+		List<String> authorities = authorities(introspector.introspect("tok"));
+
+		assertThat(authorities)
+				.contains("FB_4", "FB_5", "FB_15")     // function blocks
+				.contains("SCOPE_openid", "SCOPE_profile") // non-FB scopes pass through
+				.doesNotContain("SCOPE_FB=4_5_15;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13");
+	}
+
+	@Test
+	@DisplayName("admin scope -> SCOPE_ authority (unchanged)")
+	void adminScopeMapsToScopeAuthority() {
+		OpaqueTokenIntrospector introspector = new EspiScopeOpaqueTokenIntrospector(
+				delegateWithScope(List.of("DataCustodian_Admin_Access")));
+
+		assertThat(authorities(introspector.introspect("tok")))
+				.containsExactly("SCOPE_DataCustodian_Admin_Access");
+	}
+
+	@Test
+	@DisplayName("scope as a single space-delimited String is also supported")
+	void scopeAsStringIsParsed() {
+		OpaqueTokenIntrospector introspector = new EspiScopeOpaqueTokenIntrospector(
+				delegateWithScope("profile FB=4_10;IntervalDuration=3600"));
+
+		assertThat(authorities(introspector.introspect("tok")))
+				.contains("SCOPE_profile", "FB_4", "FB_10");
+	}
+
+	@Test
+	@DisplayName("attributes (e.g. ESPI URI claims) are preserved")
+	void attributesArePreserved() {
+		OAuth2AuthenticatedPrincipal p = new EspiScopeOpaqueTokenIntrospector(
+				delegateWithScope(List.of("DataCustodian_Admin_Access"))).introspect("tok");
+
+		assertThat(p.getName()).isEqualTo("42");
+		assertThat((Boolean) p.getAttribute("active")).isTrue();
+	}
+}

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/AuthorizationControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/AuthorizationControllerTest.java
@@ -69,7 +69,7 @@ class AuthorizationControllerTest {
 		@DisplayName("returns 403 with a customer FB-scoped token (energy-data scope)")
 		void customerFbScope_is_403() throws Exception {
 			mockMvc.perform(get("/espi/1_1/resource/Authorization")
-							.with(opaqueAuthority("SCOPE_FB_15_READ_3rd_party")))
+							.with(opaqueAuthority("FB_15")))
 					.andExpect(status().isForbidden());
 		}
 
@@ -115,7 +115,7 @@ class AuthorizationControllerTest {
 		@DisplayName("returns 403 with a customer FB-scoped token (PII scope)")
 		void customerPiiScope_is_403() throws Exception {
 			mockMvc.perform(get("/espi/1_1/resource/Authorization/" + UUID.randomUUID())
-							.with(opaqueAuthority("SCOPE_FB_54_READ_3rd_party")))
+							.with(opaqueAuthority("FB_54")))
 					.andExpect(status().isForbidden());
 		}
 

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/CustomerRESTControllerTest.java
@@ -79,6 +79,50 @@ public class CustomerRESTControllerTest extends AbstractControllerMockTest {
         }
     }
 
+    /**
+     * ESPI Customer-PII least-privilege enforcement (#157): a customer token may read /Customer only
+     * with the base Connect-My-Data FB (FB_53) AND the Customer-specific FB (FB_54). FB_53 alone, the
+     * specific FB without the base, or a different resource's FB (e.g. FB_56 CustomerAccount) are all
+     * denied — proving the Customer-PII catalog is honored rather than collapsed to a single gate.
+     */
+    @Nested
+    @DisplayName("ESPI Customer-PII FB authorization (#157)")
+    class CustomerPiiScopeGating {
+
+        @Test
+        @WithMockUser(authorities = {"FB_53", "FB_54"})
+        @DisplayName("FB_53 base + FB_54 (Customer) -> 200 OK")
+        void baseAndCustomerFbReturns200() throws Exception {
+            when(customerRepository.findAll(any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(new CustomerEntity())));
+            when(customerMapper.toDto(any(CustomerEntity.class))).thenReturn(new CustomerDto());
+
+            mockMvc.perform(get("/espi/1_1/resource/Customer").accept(MediaType.APPLICATION_XML))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @WithMockUser(authorities = "FB_53")
+        @DisplayName("FB_53 base alone (no FB_54) -> 403 (least privilege)")
+        void baseWithoutCustomerFbForbidden() throws Exception {
+            mockMvc.perform(get("/espi/1_1/resource/Customer")).andExpect(status().isForbidden());
+        }
+
+        @Test
+        @WithMockUser(authorities = "FB_54")
+        @DisplayName("FB_54 without base FB_53 -> 403")
+        void customerFbWithoutBaseForbidden() throws Exception {
+            mockMvc.perform(get("/espi/1_1/resource/Customer")).andExpect(status().isForbidden());
+        }
+
+        @Test
+        @WithMockUser(authorities = {"FB_53", "FB_56"})
+        @DisplayName("FB_53 + FB_56 (CustomerAccount FB) -> 403 on Customer (wrong resource FB)")
+        void wrongResourceFbForbidden() throws Exception {
+            mockMvc.perform(get("/espi/1_1/resource/Customer")).andExpect(status().isForbidden());
+        }
+    }
+
     @Nested
     @DisplayName("GET /espi/1_1/resource/Customer/{customerId}")
     class GetCustomer {

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ElectricPowerQualitySummaryRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ElectricPowerQualitySummaryRESTControllerTest.java
@@ -73,7 +73,7 @@ public class ElectricPowerQualitySummaryRESTControllerTest extends AbstractContr
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = "FB_17")
         @DisplayName("Should return 200 OK for FB_15 scope")
         void shouldReturn200ForFB15() throws Exception {
             when(electricPowerQualitySummaryRepository.findAll(any(Pageable.class)))
@@ -146,7 +146,7 @@ public class ElectricPowerQualitySummaryRESTControllerTest extends AbstractContr
     @DisplayName("Subscription scoped GET tests")
     class SubscriptionTests {
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = "FB_17")
         @DisplayName("Should return 200 OK for subscription collection")
         void shouldReturn200ForSubscriptionCollection() throws Exception {
             UUID subId = UUID.randomUUID();
@@ -162,7 +162,7 @@ public class ElectricPowerQualitySummaryRESTControllerTest extends AbstractContr
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = "FB_17")
         @DisplayName("Should return 200 OK for subscription resource")
         void shouldReturn200ForSubscriptionResource() throws Exception {
             UUID subId = UUID.randomUUID();

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/IntervalBlockRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/IntervalBlockRESTControllerTest.java
@@ -71,7 +71,7 @@ public class IntervalBlockRESTControllerTest extends AbstractControllerMockTest 
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 200 OK for FB_15 scope")
         void shouldReturn200ForFB15() throws Exception {
             when(intervalBlockRepository.findAll(any(Pageable.class)))
@@ -137,7 +137,7 @@ public class IntervalBlockRESTControllerTest extends AbstractControllerMockTest 
     class GetSubscriptionIntervalBlocks {
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 200 OK with list of interval blocks")
         void shouldReturn200() throws Exception {
             UUID subId = UUID.randomUUID();
@@ -174,7 +174,7 @@ public class IntervalBlockRESTControllerTest extends AbstractControllerMockTest 
     class GetSubscriptionIntervalBlock {
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 200 OK when interval block exists")
         void shouldReturn200WhenExists() throws Exception {
             UUID subId = UUID.randomUUID();

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/MeterReadingControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/MeterReadingControllerTest.java
@@ -73,7 +73,7 @@ public class MeterReadingControllerTest extends AbstractControllerMockTest {
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 200 OK for FB_15 scope")
         void shouldReturn200ForFB15() throws Exception {
             when(meterReadingRepository.findAll(any(Pageable.class)))

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ReadingTypeRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/ReadingTypeRESTControllerTest.java
@@ -73,7 +73,7 @@ public class ReadingTypeRESTControllerTest extends AbstractControllerMockTest {
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 200 OK for FB_15 scope")
         void shouldReturn200ForFB15() throws Exception {
             when(readingTypeRepository.findAll(any(Pageable.class)))

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsagePointControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsagePointControllerTest.java
@@ -81,7 +81,7 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 200 OK for FB_15 scope")
         void shouldReturn200ForFB15() throws Exception {
             when(usagePointRepository.findAll(any(Pageable.class)))
@@ -160,7 +160,7 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 200 OK for FB_15 scope")
         void shouldReturn200ForFB15() throws Exception {
             when(usagePointRepository.findAll(any(Pageable.class)))
@@ -193,7 +193,7 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 200 OK when usage point exists and user has scope")
         void shouldReturn200WhenExists() throws Exception {
             UUID subId = UUID.randomUUID();
@@ -211,7 +211,7 @@ public class UsagePointControllerTest extends AbstractControllerMockTest {
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = {"FB_4", "FB_5"})
         @DisplayName("Should return 404 Not Found when usage point does not exist")
         void shouldReturn404WhenNotExists() throws Exception {
             UUID subId = UUID.randomUUID();

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsageSummaryRESTControllerTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/web/api/UsageSummaryRESTControllerTest.java
@@ -72,7 +72,7 @@ public class UsageSummaryRESTControllerTest extends AbstractControllerMockTest {
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = "FB_15")
         @DisplayName("Should return 200 OK for FB_15 scope")
         void shouldReturn200ForFB15() throws Exception {
             when(usageSummaryRepository.findAll(any(Pageable.class)))
@@ -123,7 +123,7 @@ public class UsageSummaryRESTControllerTest extends AbstractControllerMockTest {
     class SubscriptionScopedTests {
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = "FB_15")
         @DisplayName("GET /Subscription/{subscriptionId}/UsagePoint/{usagePointId}/UsageSummary should return 200 OK")
         void shouldReturn200ForSubscriptionCollection() throws Exception {
             UUID subId = UUID.randomUUID();
@@ -138,7 +138,7 @@ public class UsageSummaryRESTControllerTest extends AbstractControllerMockTest {
         }
 
         @Test
-        @WithMockUser(authorities = "SCOPE_FB_15_READ_3rd_party")
+        @WithMockUser(authorities = "FB_15")
         @DisplayName("GET /Subscription/{subscriptionId}/UsagePoint/{usagePointId}/UsageSummary/{usageSummaryId} should return 200 OK")
         void shouldReturn200ForSubscriptionResource() throws Exception {
             UUID subId = UUID.randomUUID();


### PR DESCRIPTION
Closes #157.

## Problem (confirmed cross-service bug)

DC gated resources on a contractor-invented, non-ESPI vocabulary — `SCOPE_FB_15/16/36_READ/WRITE_3rd_party` — that has **no relationship** to the scopes the Authorization Server issues (the ESPI 4.0 grammar `FB=4_5_15;IntervalDuration=…`). A real customer token carried the authority `SCOPE_FB=4_5_15;…`, matching **none** of DC's rules → **403 on every resource**. DC API tests passed only because they stubbed the same fictional authorities (mock drift). The legacy scheme was authored by a contractor with no knowledge of ESPI 4.0 scope usage and is **scrapped**.

## What this does

**Translation** — `EspiScopeOpaqueTokenIntrospector` wraps the stock introspector, parses the scope via `openespi-common` `EspiScope`, and mints one `FB_<n>` authority per granted function block; admin/OIDC scopes pass through as `SCOPE_<x>`.

**Enforcement** (filter chain = single source of truth):
- **Usage data** (UsagePoint, MeterReading, ReadingType, IntervalBlock, LocalTimeParameters, Batch): `FB_4` (base) **AND** a commodity FB (05–11/29), or admin.
- **Usage summaries**: data-shape FBs (15/16/27/28). **Power-quality**: FB_17. Summary/PQ leaf rules (incl. Subscription-/RetailCustomer-scoped XPath) precede the broad usage-data rule so they're gated by their own FB.
- **Customer/PII — least privilege** per the ESPI Customer-PII catalog: `FB_53` base **AND** the resource-specific FB — Customer→FB_54, CustomerAccount→FB_56, CustomerAgreement→FB_57, ServiceLocation→FB_58, ServiceSupplier→FB_59, Meter→FB_60, EndDevice→FB_61, ProgramDateIdMappings→FB_62. **The FB→resource mapping is authoritative from the GBA DMD-validator conformance XSLTs.**
- **Third-party access is READ-ONLY**: all writes (POST/PUT/DELETE) require `DataCustodian_Admin_Access`. The `*_WRITE_3rd_party` notion is dropped. Deprecated **FB_36 dropped**.

**Single enforcement point** — removed the redundant scope-only `@PreAuthorize` from the 8 resource controllers (they duplicated the filter chain in the same broken vocabulary — the exact drift that caused this bug). `@EnableMethodSecurity` stays on for **Phase 2 resource-ownership** checks (resource ∈ subscription's usage points — a *different* check than URL scope). The admin-only `@PreAuthorize` on ApplicationInformation/Authorization are kept as deliberate defense-in-depth on the crown-jewel endpoints (correct vocabulary).

## Deferred (noted, not regressions — content-level, beyond URL enforcement)
- **FB_55 (Address)** — a field inside Customer, not an endpoint → response-shaping (Phase 2 data minimization).
- **Nested-XPath per-leaf** customer gating — XPath customer subtree currently floors at FB_53+FB_54.

## Tests (all green)
- Introspector unit test (FB mapping + admin passthrough).
- Migrated the 7 affected controller tests to FB authorities.
- **Customer-PII least-privilege tests**: FB_53+FB_54 → 200; FB_53-alone, FB_54-without-base, and FB_53+FB_56 (wrong resource FB) → 403.
- Local: the touched controller + config tests run **green** (`UsagePoint/MeterReading/ReadingType/IntervalBlock/UsageSummary/ElectricPowerQuality/Authorization/Customer*` + introspector).

> Note: DC **is** covered by CI (unlike authserver), so this PR gets real pipeline validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)