### PR TITLE
fix(#160): correct AS↔DC token/introspection wire format to ESPI standard + pin contract (#150)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,42 @@
+# Cross-service wire contracts (AS ↔ DC)
+
+Canonical JSON examples of the HTTP wire formats exchanged between the Authorization
+Server and the Data Custodian. These files are the **single source of truth** both
+services bind to in their own tests — a lightweight, framework-free consumer-driven
+contract suited to standalone Spring Boot services (deployed independently on EC2),
+**not** a Spring Cloud microservice mesh.
+
+## How the contract is enforced (no Spring Cloud, no Pact broker)
+
+For each contract, two tests bind to the same file here:
+
+- **Producer test** asserts the service's *actual* output matches this file.
+- **Consumer test** asserts the service correctly *parses* this file.
+
+If either side's wire format drifts from the file, that side's test fails. The fixture
+is reviewed in PRs, so a deliberate wire change is a visible diff to this directory plus
+a coordinated update on both sides.
+
+What these contracts cover: the **wire format** (field names, types, the ESPI scope
+grammar). What they deliberately do NOT cover: TLS, ingress, CORS, timeouts — those are
+EC2 deployment concerns, not wire-format concerns.
+
+## Contracts
+
+The token-response / introspection wire format is defined by the **ESPI 4.0 standard** itself
+(NAESB REQ.21 — its own example shows `"resourceURI":".../resource/Batch/Subscription/{id}"`,
+`"scope":"FB=...;..."`, no `*_id` fields, `customerResourceURI` may be `""`). These fixtures
+reproduce that standard shape for the two grant types:
+
+| File | Grant type | `resourceURI` / `customerResourceURI` form |
+|------|------------|--------------------------------------------|
+| `token-response-subscription.json` | Authorization Code (Subscription) | `Batch/Subscription/{id}` / `Batch/RetailCustomer/{rc}` |
+| `token-response-bulk.json` | Client Credentials (Bulk) | `Batch/Bulk/{bulkId}` / `Batch/Bulk/{bulkRcId}` |
+
+- **Producer** (AS token endpoint / introspection, fed by DC `SubscriptionProvisioningServiceImpl`
+  via `EspiBatchUri`) must emit these URI forms and only the three `*URI` fields.
+- **Consumer** (DC `ResourceValidationFilter` / `EspiScopeOpaqueTokenIntrospector`) parses ids back
+  out of the URIs via the same `EspiBatchUri`, and the `FB=...` scope via `EspiScope`.
+
+UUIDs/ids/tokens in the fixtures are illustrative; the contract is the **shape** — field names,
+the `Batch/{Subscription|Bulk|RetailCustomer}` URI forms, and the ESPI `FB=...` scope grammar.

--- a/contracts/token-response-bulk.json
+++ b/contracts/token-response-bulk.json
@@ -1,0 +1,9 @@
+{
+  "access_token": "OPAQUE_ACCESS_TOKEN",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "FB=1_3_4_5_10_11_35;BlockDuration=daily;BR=1",
+  "resourceURI": "https://utilityapi.com/DataCustodian/espi/1_1/resource/Batch/Bulk/BULK_1",
+  "authorizationURI": "https://utilityapi.com/DataCustodian/espi/1_1/resource/Authorization/CLIENTCREDS",
+  "customerResourceURI": "https://utilityapi.com/DataCustodian/espi/1_1/resource/Batch/Bulk/BULK_RC_1"
+}

--- a/contracts/token-response-subscription.json
+++ b/contracts/token-response-subscription.json
@@ -1,0 +1,10 @@
+{
+  "access_token": "OPAQUE_ACCESS_TOKEN",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "OPAQUE_REFRESH_TOKEN",
+  "scope": "FB=4_5_15;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13",
+  "resourceURI": "https://utilityapi.com/DataCustodian/espi/1_1/resource/Batch/Subscription/503888",
+  "authorizationURI": "https://utilityapi.com/DataCustodian/espi/1_1/resource/Authorization/503888",
+  "customerResourceURI": "https://utilityapi.com/DataCustodian/espi/1_1/resource/Batch/RetailCustomer/503888"
+}

--- a/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/service/EspiTokenResponseSuccessHandler.java
+++ b/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/service/EspiTokenResponseSuccessHandler.java
@@ -75,13 +75,12 @@ public class EspiTokenResponseSuccessHandler implements AuthenticationSuccessHan
 	private final OAuth2AuthorizationService authorizationService;
 	private final OAuth2AccessTokenResponseHttpWriter responseWriter = new OAuth2AccessTokenResponseHttpWriter();
 
+	// ESPI 4.0 (REQ.21) surfaces only the three canonical URIs in the token response; the bare *_id
+	// claims were non-standard and were removed in #160 (consumers parse ids from the URIs).
 	private static final Set<String> ESPI_URI_CLAIMS = Set.of(
 			GrantBackchannelTokenCustomizer.CLAIM_RESOURCE_URI,
 			GrantBackchannelTokenCustomizer.CLAIM_AUTHORIZATION_URI,
-			GrantBackchannelTokenCustomizer.CLAIM_CUSTOMER_RESOURCE_URI,
-			GrantBackchannelTokenCustomizer.CLAIM_AUTHORIZATION_ID,
-			GrantBackchannelTokenCustomizer.CLAIM_RESOURCE_SUBSCRIPTION_ID,
-			GrantBackchannelTokenCustomizer.CLAIM_CUSTOMER_SUBSCRIPTION_ID
+			GrantBackchannelTokenCustomizer.CLAIM_CUSTOMER_RESOURCE_URI
 	);
 
 	@Override

--- a/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/service/GrantBackchannelTokenCustomizer.java
+++ b/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/service/GrantBackchannelTokenCustomizer.java
@@ -60,10 +60,10 @@ import java.util.UUID;
  * </ol>
  *
  * <h2>Claim names</h2>
- * Match the ESPI 1.1/4.0 token-response wire format the third party expects:
- * {@code resourceURI}, {@code authorizationURI}, {@code customerResourceURI}. The auxiliary ids
- * ({@code authorization_id}, {@code resource_subscription_id}, {@code customer_subscription_id})
- * are surfaced as snake-case claims for AS-side audit and operator tooling.
+ * Exactly the ESPI 4.0 (REQ.21) token-response wire format the third party expects:
+ * {@code resourceURI}, {@code authorizationURI}, {@code customerResourceURI}. Consumers parse any
+ * needed ids out of those canonical URIs (see {@code EspiBatchUri}); the previously-emitted bare
+ * {@code *_id} claims were non-standard and were removed in #160.
  *
  * <h2>Failure handling</h2>
  * Any {@link DataCustodianBackchannelException} is rethrown as an {@link OAuth2AuthenticationException}
@@ -79,9 +79,6 @@ public class GrantBackchannelTokenCustomizer implements OAuth2TokenCustomizer<OA
 	public static final String CLAIM_RESOURCE_URI = "resourceURI";
 	public static final String CLAIM_AUTHORIZATION_URI = "authorizationURI";
 	public static final String CLAIM_CUSTOMER_RESOURCE_URI = "customerResourceURI";
-	public static final String CLAIM_AUTHORIZATION_ID = "authorization_id";
-	public static final String CLAIM_RESOURCE_SUBSCRIPTION_ID = "resource_subscription_id";
-	public static final String CLAIM_CUSTOMER_SUBSCRIPTION_ID = "customer_subscription_id";
 
 	private final DataCustodianBackchannelClient backchannelClient;
 
@@ -139,6 +136,10 @@ public class GrantBackchannelTokenCustomizer implements OAuth2TokenCustomizer<OA
 	}
 
 	private static void writeClaims(OAuth2TokenClaimsContext context, BackchannelResponse response) {
+		// ESPI 4.0 (REQ.21) token-response / introspection augmentation carries ONLY the three canonical
+		// URIs — resourceURI, authorizationURI, customerResourceURI. The bare *_id fields were
+		// non-standard duplicates of the ids already embedded in those URIs (and customer_subscription_id
+		// was mislabeled); consumers parse ids from the URIs via EspiBatchUri instead. Removed per #160.
 		var claims = context.getClaims();
 		if (response.resourceUri() != null) {
 			claims.claim(CLAIM_RESOURCE_URI, response.resourceUri());
@@ -148,15 +149,6 @@ public class GrantBackchannelTokenCustomizer implements OAuth2TokenCustomizer<OA
 		}
 		if (response.customerResourceUri() != null) {
 			claims.claim(CLAIM_CUSTOMER_RESOURCE_URI, response.customerResourceUri());
-		}
-		if (response.authorizationId() != null) {
-			claims.claim(CLAIM_AUTHORIZATION_ID, response.authorizationId().toString());
-		}
-		if (response.resourceSubscriptionId() != null) {
-			claims.claim(CLAIM_RESOURCE_SUBSCRIPTION_ID, response.resourceSubscriptionId().toString());
-		}
-		if (response.customerSubscriptionId() != null) {
-			claims.claim(CLAIM_CUSTOMER_SUBSCRIPTION_ID, response.customerSubscriptionId().toString());
 		}
 	}
 }

--- a/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/AuthCodeFlowOrchestrationIntegrationTest.java
+++ b/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/AuthCodeFlowOrchestrationIntegrationTest.java
@@ -186,9 +186,11 @@ class AuthCodeFlowOrchestrationIntegrationTest extends AbstractAuthserverIntegra
 				.andExpect(jsonPath("$.resourceURI").value(resourceUri))
 				.andExpect(jsonPath("$.authorizationURI").value(authorizationUri))
 				.andExpect(jsonPath("$.customerResourceURI").value(customerResourceUri))
-				.andExpect(jsonPath("$.authorization_id").value(authorizationId.toString()))
-				.andExpect(jsonPath("$.resource_subscription_id").value(resourceSubscriptionId.toString()))
-				.andExpect(jsonPath("$.customer_subscription_id").value(customerSubscriptionId.toString()));
+				// ESPI 4.0 token response carries only the three canonical URIs; the *_id claims were
+				// non-standard and removed in #160.
+				.andExpect(jsonPath("$.authorization_id").doesNotExist())
+				.andExpect(jsonPath("$.resource_subscription_id").doesNotExist())
+				.andExpect(jsonPath("$.customer_subscription_id").doesNotExist());
 
 		// The back-channel was called with the customer-selection context carried through the flow.
 		ArgumentCaptor<BackchannelRequest> captor = ArgumentCaptor.forClass(BackchannelRequest.class);

--- a/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/service/GrantBackchannelTokenCustomizerTest.java
+++ b/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/service/GrantBackchannelTokenCustomizerTest.java
@@ -106,9 +106,8 @@ class GrantBackchannelTokenCustomizerTest {
 				.containsEntry(GrantBackchannelTokenCustomizer.CLAIM_AUTHORIZATION_URI,
 						"https://dc.example/Authorization/" + AUTH_ID)
 				.containsEntry(GrantBackchannelTokenCustomizer.CLAIM_CUSTOMER_RESOURCE_URI,
-						"https://dc.example/RetailCustomer/42/Customer/" + CUST_SUB_ID)
-				.containsEntry(GrantBackchannelTokenCustomizer.CLAIM_AUTHORIZATION_ID,
-						AUTH_ID.toString());
+						"https://dc.example/RetailCustomer/42/Customer/" + CUST_SUB_ID);
+		// *_id claims removed in #160 — consumers parse ids from the canonical URIs (EspiBatchUri).
 	}
 
 	@Test
@@ -159,8 +158,7 @@ class GrantBackchannelTokenCustomizerTest {
 		assertThat(claims)
 				.containsEntry(GrantBackchannelTokenCustomizer.CLAIM_RESOURCE_URI,
 						"https://dc.example/Subscription/" + RES_SUB_ID)
-				.doesNotContainKey(GrantBackchannelTokenCustomizer.CLAIM_CUSTOMER_RESOURCE_URI)
-				.doesNotContainKey(GrantBackchannelTokenCustomizer.CLAIM_CUSTOMER_SUBSCRIPTION_ID);
+				.doesNotContainKey(GrantBackchannelTokenCustomizer.CLAIM_CUSTOMER_RESOURCE_URI);
 	}
 
 	@Test

--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/service/impl/SubscriptionProvisioningServiceImpl.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/service/impl/SubscriptionProvisioningServiceImpl.java
@@ -28,6 +28,7 @@ import org.greenbuttonalliance.espi.common.repositories.usage.AuthorizationRepos
 import org.greenbuttonalliance.espi.common.repositories.usage.RetailCustomerRepository;
 import org.greenbuttonalliance.espi.common.repositories.usage.UsagePointRepository;
 import org.greenbuttonalliance.espi.common.scope.EspiScope;
+import org.greenbuttonalliance.espi.common.uri.EspiBatchUri;
 import org.greenbuttonalliance.espi.common.service.EspiIdGeneratorService;
 import org.greenbuttonalliance.espi.common.service.SubscriptionProvisioningService;
 import org.springframework.beans.factory.annotation.Value;
@@ -171,7 +172,12 @@ public class SubscriptionProvisioningServiceImpl implements SubscriptionProvisio
 		authorization.setThirdParty(command.clientId());
 		authorization.setStatus(AuthorizationEntity.STATUS_ACTIVE);
 		if (includesPii) {
-			authorization.setCustomerResourceURI(command.customerResourceUri());
+			// Build the canonical ESPI Batch/RetailCustomer URI from the retail-customer id DC already
+			// holds, rather than trusting the round-tripped handoff value (#160). The handoff's
+			// customer_resource_uri is now vestigial — removing it from the back-channel request/handoff
+			// is a follow-up structural cleanup.
+			authorization.setCustomerResourceURI(
+					EspiBatchUri.batchRetailCustomer(resourceBaseUri, command.retailCustomerId()));
 		}
 		return authorization;
 	}
@@ -191,11 +197,14 @@ public class SubscriptionProvisioningServiceImpl implements SubscriptionProvisio
 		return subscription;
 	}
 
+	// Canonical ESPI 4.0 Batch resource URIs via the single builder/parser shared with the consumers
+	// (DC ResourceValidationFilter) — see EspiBatchUri / #160. The previous "/Subscription/{id}" form
+	// omitted the required "/Batch/" segment and so failed DC's own resource validation.
 	private String subscriptionUri(UUID subscriptionId) {
-		return resourceBaseUri + "/Subscription/" + subscriptionId;
+		return EspiBatchUri.batchSubscription(resourceBaseUri, subscriptionId);
 	}
 
 	private String authorizationUri(UUID authorizationId) {
-		return resourceBaseUri + "/Authorization/" + authorizationId;
+		return EspiBatchUri.authorization(resourceBaseUri, authorizationId);
 	}
 }

--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/uri/EspiBatchUri.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/uri/EspiBatchUri.java
@@ -1,0 +1,133 @@
+/*
+ *
+ *        Copyright (c) 2025 Green Button Alliance, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.greenbuttonalliance.espi.common.uri;
+
+import java.util.Optional;
+
+/**
+ * The single canonical builder and parser for the ESPI 4.0 <em>Batch</em> resource URIs carried in the
+ * token-response / introspection {@code resourceURI}, {@code authorizationURI}, and
+ * {@code customerResourceURI} fields (NAESB ESPI 4.0, REQ.21.6.2.1 API Interface).
+ *
+ * <p>The canonical forms (relative to a resource base such as
+ * {@code https://{host}/DataCustodian/espi/1_1/resource}) are:</p>
+ * <ul>
+ *   <li>{@code .../Batch/Subscription/{subscriptionId}} — Subscription (authorization-code) flow</li>
+ *   <li>{@code .../Batch/Bulk/{bulkId}} — Bulk (client-credentials) flow; the {@code bulkId} comes from
+ *       the scope's {@code BR=} parameter</li>
+ *   <li>{@code .../Batch/RetailCustomer/{retailCustomerId}} — customer/PII batch</li>
+ *   <li>{@code .../Authorization/{authorizationId}}</li>
+ * </ul>
+ *
+ * <p><strong>Why one class builds and parses:</strong> the producer (DC subscription provisioning) and
+ * the consumers (DC {@code ResourceValidationFilter}, the resource-server introspector) previously
+ * encoded these URL formats independently and drifted — the producer emitted {@code /Subscription/{id}}
+ * while the consumer expected {@code /Batch/Subscription/{id}} (issue #160). Routing both sides through
+ * this single class makes that drift structurally impossible.</p>
+ */
+public final class EspiBatchUri {
+
+	private EspiBatchUri() {
+	}
+
+	// ------------------------------------------------------------------ builders
+
+	/** {@code {resourceBase}/Batch/Subscription/{subscriptionId}}. */
+	public static String batchSubscription(String resourceBase, Object subscriptionId) {
+		return base(resourceBase) + "/Batch/Subscription/" + require(subscriptionId, "subscriptionId");
+	}
+
+	/** {@code {resourceBase}/Batch/Bulk/{bulkId}}. */
+	public static String batchBulk(String resourceBase, Object bulkId) {
+		return base(resourceBase) + "/Batch/Bulk/" + require(bulkId, "bulkId");
+	}
+
+	/** {@code {resourceBase}/Batch/RetailCustomer/{retailCustomerId}}. */
+	public static String batchRetailCustomer(String resourceBase, Object retailCustomerId) {
+		return base(resourceBase) + "/Batch/RetailCustomer/" + require(retailCustomerId, "retailCustomerId");
+	}
+
+	/** {@code {resourceBase}/Authorization/{authorizationId}}. */
+	public static String authorization(String resourceBase, Object authorizationId) {
+		return base(resourceBase) + "/Authorization/" + require(authorizationId, "authorizationId");
+	}
+
+	// ------------------------------------------------------------------ parsers
+
+	/** Extract {@code subscriptionId} from a {@code .../Batch/Subscription/{id}...} URI. */
+	public static Optional<String> subscriptionId(String uri) {
+		return idAfter(uri, "/Batch/Subscription/");
+	}
+
+	/** Extract {@code bulkId} from a {@code .../Batch/Bulk/{id}...} URI. */
+	public static Optional<String> bulkId(String uri) {
+		return idAfter(uri, "/Batch/Bulk/");
+	}
+
+	/** Extract {@code retailCustomerId} from a {@code .../Batch/RetailCustomer/{id}...} URI. */
+	public static Optional<String> retailCustomerId(String uri) {
+		return idAfter(uri, "/Batch/RetailCustomer/");
+	}
+
+	/** Extract {@code authorizationId} from a {@code .../Authorization/{id}...} URI. */
+	public static Optional<String> authorizationId(String uri) {
+		return idAfter(uri, "/Authorization/");
+	}
+
+	/**
+	 * Return the path segment immediately following {@code marker}, tolerant of deeper path segments and
+	 * query/fragment suffixes — e.g. {@code .../Batch/Subscription/42/UsagePoint/7?x=1} yields {@code 42}.
+	 * Returns empty when the marker is absent or the id segment is empty.
+	 */
+	static Optional<String> idAfter(String uri, String marker) {
+		if (uri == null) {
+			return Optional.empty();
+		}
+		int at = uri.indexOf(marker);
+		if (at < 0) {
+			return Optional.empty();
+		}
+		int start = at + marker.length();
+		int end = start;
+		while (end < uri.length()) {
+			char c = uri.charAt(end);
+			if (c == '/' || c == '?' || c == '#') {
+				break;
+			}
+			end++;
+		}
+		String id = uri.substring(start, end);
+		return id.isEmpty() ? Optional.empty() : Optional.of(id);
+	}
+
+	private static String base(String resourceBase) {
+		if (resourceBase == null || resourceBase.isBlank()) {
+			throw new IllegalArgumentException("resourceBase is required");
+		}
+		String trimmed = resourceBase.strip();
+		return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+	}
+
+	private static String require(Object id, String name) {
+		if (id == null || id.toString().isBlank()) {
+			throw new IllegalArgumentException(name + " is required");
+		}
+		return id.toString();
+	}
+}

--- a/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/service/impl/SubscriptionProvisioningServiceImplTest.java
+++ b/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/service/impl/SubscriptionProvisioningServiceImplTest.java
@@ -102,7 +102,7 @@ class SubscriptionProvisioningServiceImplTest {
 
 		assertThat(result.resourceSubscriptionId()).isNotNull();
 		assertThat(result.customerSubscriptionId()).isNull();
-		assertThat(result.resourceUri()).startsWith(BASE_URI + "/Subscription/");
+		assertThat(result.resourceUri()).startsWith(BASE_URI + "/Batch/Subscription/"); // ESPI standard Batch form (#160)
 		assertThat(result.authorizationUri()).startsWith(BASE_URI + "/Authorization/");
 		assertThat(result.customerResourceUri()).isNull();
 
@@ -134,10 +134,10 @@ class SubscriptionProvisioningServiceImplTest {
 
 		assertThat(result.resourceSubscriptionId()).isNotNull();
 		assertThat(result.customerSubscriptionId()).isNotNull();
-		assertThat(result.customerResourceUri()).isEqualTo(PII_CUSTOMER_URI);
+		assertThat(result.customerResourceUri()).isEqualTo(BASE_URI + "/Batch/RetailCustomer/" + CUSTOMER_ID);
 
 		AuthorizationEntity saved = captureSavedAuthorization();
-		assertThat(saved.getCustomerResourceURI()).isEqualTo(PII_CUSTOMER_URI);
+		assertThat(saved.getCustomerResourceURI()).isEqualTo(BASE_URI + "/Batch/RetailCustomer/" + CUSTOMER_ID);
 		assertThat(saved.getSubscriptions()).hasSize(2);
 	}
 
@@ -152,7 +152,7 @@ class SubscriptionProvisioningServiceImplTest {
 		assertThat(result.resourceSubscriptionId()).isNull();
 		assertThat(result.resourceUri()).isNull();
 		assertThat(result.customerSubscriptionId()).isNotNull();
-		assertThat(result.customerResourceUri()).isEqualTo(PII_CUSTOMER_URI);
+		assertThat(result.customerResourceUri()).isEqualTo(BASE_URI + "/Batch/RetailCustomer/" + CUSTOMER_ID);
 
 		AuthorizationEntity saved = captureSavedAuthorization();
 		assertThat(saved.getResourceURI()).isNull();

--- a/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/uri/EspiBatchUriTest.java
+++ b/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/uri/EspiBatchUriTest.java
@@ -1,0 +1,99 @@
+/*
+ *
+ *        Copyright (c) 2025 Green Button Alliance, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.greenbuttonalliance.espi.common.uri;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link EspiBatchUri} — the single canonical ESPI Batch-URI builder/parser (#160).
+ */
+@DisplayName("EspiBatchUri (canonical ESPI Batch URI builder/parser) #160")
+class EspiBatchUriTest {
+
+	private static final String BASE = "https://utilityapi.com/DataCustodian/espi/1_1/resource";
+
+	@Test
+	@DisplayName("builders produce the ESPI 4.0 standard Batch forms")
+	void buildersProduceStandardForms() {
+		assertThat(EspiBatchUri.batchSubscription(BASE, "503888"))
+				.isEqualTo(BASE + "/Batch/Subscription/503888");
+		assertThat(EspiBatchUri.batchBulk(BASE, "BULK_1"))
+				.isEqualTo(BASE + "/Batch/Bulk/BULK_1");
+		assertThat(EspiBatchUri.batchRetailCustomer(BASE, "503888"))
+				.isEqualTo(BASE + "/Batch/RetailCustomer/503888");
+		assertThat(EspiBatchUri.authorization(BASE, "503888"))
+				.isEqualTo(BASE + "/Authorization/503888");
+	}
+
+	@Test
+	@DisplayName("a trailing slash on the base is normalized away")
+	void normalizesTrailingSlash() {
+		assertThat(EspiBatchUri.batchSubscription(BASE + "/", "1"))
+				.isEqualTo(BASE + "/Batch/Subscription/1");
+	}
+
+	@Test
+	@DisplayName("build then parse round-trips the id (UUID and alphanumeric)")
+	void roundTrips() {
+		UUID id = UUID.randomUUID();
+		assertThat(EspiBatchUri.subscriptionId(EspiBatchUri.batchSubscription(BASE, id)))
+				.contains(id.toString());
+		assertThat(EspiBatchUri.bulkId(EspiBatchUri.batchBulk(BASE, "1dfa07c5740a_118328")))
+				.contains("1dfa07c5740a_118328");
+		assertThat(EspiBatchUri.retailCustomerId(EspiBatchUri.batchRetailCustomer(BASE, "503888")))
+				.contains("503888");
+		assertThat(EspiBatchUri.authorizationId(EspiBatchUri.authorization(BASE, "CLIENTCREDS")))
+				.contains("CLIENTCREDS");
+	}
+
+	@Test
+	@DisplayName("parser extracts the id from deeper paths and query strings")
+	void parsesDeepPathsAndQueryStrings() {
+		assertThat(EspiBatchUri.subscriptionId(BASE + "/Batch/Subscription/503888/UsagePoint/7"))
+				.contains("503888");
+		assertThat(EspiBatchUri.bulkId(BASE + "/Batch/Bulk/1?published-min=2012-04-01T04:00:00Z"))
+				.contains("1");
+	}
+
+	@Test
+	@DisplayName("parser returns empty for a non-matching or null URI")
+	void parserEmptyWhenAbsent() {
+		// the legacy (wrong) non-Batch form must NOT parse as a Batch subscription
+		assertThat(EspiBatchUri.subscriptionId(BASE + "/Subscription/503888")).isEmpty();
+		assertThat(EspiBatchUri.subscriptionId(null)).isEmpty();
+		assertThat(EspiBatchUri.bulkId(BASE + "/Batch/Subscription/1")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("builders reject a blank base or id")
+	void buildersRejectBlankInputs() {
+		assertThatThrownBy(() -> EspiBatchUri.batchSubscription(" ", "1"))
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> EspiBatchUri.batchSubscription(BASE, ""))
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> EspiBatchUri.authorization(BASE, null))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/contract/IntrospectionWireContractTest.java
+++ b/openespi-datacustodian/src/test/java/org/greenbuttonalliance/espi/datacustodian/contract/IntrospectionWireContractTest.java
@@ -1,0 +1,106 @@
+/*
+ *
+ *        Copyright (c) 2025 Green Button Alliance, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.greenbuttonalliance.espi.datacustodian.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.greenbuttonalliance.espi.common.scope.EspiScope;
+import org.greenbuttonalliance.espi.common.uri.EspiBatchUri;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * DC <em>consumer</em> side of the AS↔DC token/introspection wire contract (#150 / #160).
+ *
+ * <p>Binds the Data Custodian's consumption logic — {@link EspiBatchUri} (id parsing, as the
+ * resource-server / {@code ResourceValidationFilter} does) and {@link EspiScope} (FB-scope parsing,
+ * as the introspector does) — to the shared, ESPI-standard fixtures in the repo-root
+ * {@code contracts/} directory. If the wire format drifts from the standard on either side, the
+ * producer test ({@code SubscriptionProvisioningServiceImplTest}) or this consumer test fails.</p>
+ *
+ * <p>Pure unit test (no Spring context, no Docker) — runs in CI as part of the DC module.</p>
+ */
+@DisplayName("AS↔DC token/introspection wire contract — DC consumer (#150/#160)")
+class IntrospectionWireContractTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final Path CONTRACTS = locateContractsDir();
+
+	@Test
+	@DisplayName("Subscription (auth-code) token response conforms to the ESPI standard")
+	void subscriptionConformsToStandard() throws Exception {
+		JsonNode c = readFixture("token-response-subscription.json");
+
+		assertNoLegacyIdFields(c);
+		assertFbGrammarOnlyScope(c.get("scope").asText(), 4, 5, 15);
+
+		// Consumer parses ids out of the canonical Batch URIs (the contract).
+		assertThat(EspiBatchUri.subscriptionId(c.get("resourceURI").asText())).contains("503888");
+		assertThat(EspiBatchUri.authorizationId(c.get("authorizationURI").asText())).contains("503888");
+		assertThat(EspiBatchUri.retailCustomerId(c.get("customerResourceURI").asText())).contains("503888");
+	}
+
+	@Test
+	@DisplayName("Bulk (client-credentials) token response conforms to the ESPI standard")
+	void bulkConformsToStandard() throws Exception {
+		JsonNode c = readFixture("token-response-bulk.json");
+
+		assertNoLegacyIdFields(c);
+		assertFbGrammarOnlyScope(c.get("scope").asText(), 1, 3, 4, 5, 10, 11, 35);
+
+		assertThat(EspiBatchUri.bulkId(c.get("resourceURI").asText())).contains("BULK_1");
+		assertThat(EspiBatchUri.authorizationId(c.get("authorizationURI").asText())).contains("CLIENTCREDS");
+		assertThat(EspiBatchUri.bulkId(c.get("customerResourceURI").asText())).contains("BULK_RC_1");
+	}
+
+	private static void assertNoLegacyIdFields(JsonNode c) {
+		// ESPI 4.0 carries only the three *URI fields; the bare *_id claims were removed (#160).
+		assertThat(c.has("authorization_id")).as("authorization_id must be absent").isFalse();
+		assertThat(c.has("resource_subscription_id")).as("resource_subscription_id must be absent").isFalse();
+		assertThat(c.has("customer_subscription_id")).as("customer_subscription_id must be absent").isFalse();
+	}
+
+	private static void assertFbGrammarOnlyScope(String scope, int... expectedFbs) {
+		assertThat(scope).startsWith("FB=").doesNotContain("openid").doesNotContain("profile");
+		EspiScope parsed = EspiScope.parse(scope);
+		for (int fb : expectedFbs) {
+			assertThat(parsed.containsFunctionBlock(fb)).as("scope must grant FB_" + fb).isTrue();
+		}
+	}
+
+	private static JsonNode readFixture(String name) throws Exception {
+		return MAPPER.readTree(Files.readString(CONTRACTS.resolve(name)));
+	}
+
+	/** Resolve repo-root {@code contracts/} whether tests run from the module dir or the repo root. */
+	private static Path locateContractsDir() {
+		for (Path candidate : new Path[] { Path.of("..", "contracts"), Path.of("contracts") }) {
+			if (Files.isDirectory(candidate)) {
+				return candidate;
+			}
+		}
+		throw new IllegalStateException(
+				"contracts/ directory not found from " + Path.of("").toAbsolutePath());
+	}
+}


### PR DESCRIPTION
Closes #160. Refs #150.

## Problem (live bug, surfaced while scoping the #150 contract)

The C4 token-response/introspection augmentation diverged from the **ESPI 4.0 standard** (NAESB REQ.21 — its own example shows `"resourceURI":".../resource/Batch/Subscription/{id}"`, `"scope":"FB=...;..."`, only the three `*URI` fields, `customerResourceURI` may be `""`).

The producer emitted `/resource/Subscription/{id}` — **missing `/Batch/`** — which DC's own `ResourceValidationFilter` already rejected (it expects `/resource/Batch/Subscription`). So **a real customer token failed DC's resource validation**. The AS also emitted three non-standard `*_id` claims (one mislabeled `customer_subscription_id` that was actually the retail-customer id).

## Root-cause fix — one canonical builder/parser (no string patch)

The drift existed because producer and consumers each encoded the URL format independently. 

- **`EspiBatchUri`** (`openespi-common`) — the single home for the ESPI Batch URL format: builds *and* parses `Batch/{Subscription|Bulk|RetailCustomer}/{id}` and `Authorization/{id}`. A test asserts the legacy `/Subscription/{id}` form does **not** parse as a Batch subscription.
- **Producer** (`SubscriptionProvisioningServiceImpl`) builds **all three** canonical URIs via `EspiBatchUri` — `resourceURI`→`Batch/Subscription`, `authorizationURI`→`Authorization`, `customerResourceURI`→`Batch/RetailCustomer/{rc}` (built from the retail-customer id DC holds, not the round-tripped handoff value).
- **`*_id` claims dropped** from the AS customizer + token-response handler; consumers parse ids from the canonical URIs. (Verified `openespi-thirdparty` doesn't read them.)

## Contract pinned (#150) — lightweight, no Spring Cloud

These are standalone EC2 services, not a microservice mesh — so a shared-fixture consumer-driven contract, not Spring Cloud Contract:
- `contracts/` holds the two **ESPI-standard** fixtures (Subscription + Bulk) as the single source of truth + a README.
- **DC consumer test** binds DC's parsing (`EspiBatchUri` + `EspiScope`) to the fixtures (asserts `*_id` absent, FB-grammar-only scope). **Producer test** asserts all three emitted URIs are canonical — so the contract is verified on **both** sides.

## Verification
- common **18/18** · DC contract + controller **9/9** · AS `testcontainers-it` **20/20** (the #148 orchestration test confirms `*_id` gone + the URIs flow).
- DC and common run in CI; the AS changes are covered by the tagged `testcontainers-it` step.

## Follow-ups (noted in the commit)
- Remove the now-vestigial `customer_resource_uri` from the back-channel request/handoff (structural cleanup).
- Empirically verify `/oauth2/introspect` surfaces the URI claims (note: DC enforces from its own stored `Authorization.resourceURI`, now the Batch form — the live path is fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)