### PR TITLE
refactor(#158): collapse NotificationServiceImpl to a single constructor

### DIFF
--- a/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/service/impl/NotificationServiceImpl.java
+++ b/openespi-common/src/main/java/org/greenbuttonalliance/espi/common/service/impl/NotificationServiceImpl.java
@@ -28,7 +28,6 @@ import org.greenbuttonalliance.espi.common.service.NotificationService;
 import org.greenbuttonalliance.espi.common.service.SubscriptionService;
 import org.greenbuttonalliance.espi.common.uri.EspiBatchUri;
 import org.greenbuttonalliance.espi.common.xml.BatchListXmlCodec;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -54,26 +53,18 @@ public class NotificationServiceImpl implements NotificationService {
 	private final SubscriptionService subscriptionService;
 
 	/**
-	 * Production constructor. Builds a standalone {@link RestClient} for posting ESPI
-	 * {@code BatchList} notifications to Third Party {@code thirdPartyNotifyUri} endpoints.
-	 * Replaces the legacy {@code RestTemplate} (#158).
+	 * Builds the {@link RestClient} once from the autoconfigured {@link RestClient.Builder} for
+	 * posting ESPI {@code BatchList} notifications to Third Party {@code thirdPartyNotifyUri}
+	 * endpoints. Replaces the legacy {@code RestTemplate} (#158).
+	 *
+	 * <p>This is the sole constructor, so Spring selects it for injection without {@code @Autowired}.
+	 * Tests pass their own {@code RestClient.builder()} (e.g. pointed at a stub receiver).</p>
 	 */
-	@Autowired
-	public NotificationServiceImpl(AuthorizationRepository authorizationRepository,
-								   AuthorizationService authorizationService,
-								   SubscriptionService subscriptionService) {
-		this(RestClient.create(), authorizationRepository, authorizationService, subscriptionService);
-	}
-
-	/**
-	 * Test/seam constructor allowing a pre-configured {@link RestClient} (e.g. pointed at a
-	 * stub receiver) to be injected.
-	 */
-	public NotificationServiceImpl(RestClient restClient,
+	public NotificationServiceImpl(RestClient.Builder restClientBuilder,
 								   AuthorizationRepository authorizationRepository,
 								   AuthorizationService authorizationService,
 								   SubscriptionService subscriptionService) {
-		this.restClient = restClient;
+		this.restClient = restClientBuilder.build();
 		this.authorizationRepository = authorizationRepository;
 		this.authorizationService = authorizationService;
 		this.subscriptionService = subscriptionService;

--- a/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/service/impl/NotificationServiceImplWireContractTest.java
+++ b/openespi-common/src/test/java/org/greenbuttonalliance/espi/common/service/impl/NotificationServiceImplWireContractTest.java
@@ -107,7 +107,7 @@ class NotificationServiceImplWireContractTest {
 
 		// repositories/services are unused by the subscription notify path
 		NotificationServiceImpl service =
-				new NotificationServiceImpl(RestClient.create(), null, null, null);
+				new NotificationServiceImpl(RestClient.builder(), null, null, null);
 
 		service.notify(subscription, start, end);
 


### PR DESCRIPTION
Follow-up cleanup to #158 (PR #163).

The #158 sender migration introduced **two** constructors on `NotificationServiceImpl` — a production one (built `RestClient` internally) and a test-seam one (injected a pre-built `RestClient`). That shape was the footgun that briefly turned CI red: with two constructors and neither `@Autowired`, Spring reported *"No default constructor found"* and every full-context `@SpringBootTest` in common failed. The fix at the time was to add `@Autowired` — but the cleaner answer is to not have two constructors at all.

## Change
- **Single constructor** injecting the autoconfigured `RestClient.Builder`, building the client **once**. As the sole constructor, Spring selects it for injection with **no `@Autowired`** needed — the disambiguation hazard is gone.
- Test passes its own `RestClient.builder()` (still points the JDK `HttpServer` stub at the service); no test-only production constructor remains.

## Why `RestClient.Builder` (not internal `RestClient.create()`)
`RestClientAutoConfiguration` always provides a prototype `RestClient.Builder` when spring-web is on the classpath, so injecting it is safe in every context and keeps the client configurable/test-injectable through one path — which was the only reason the second constructor existed.

Verified locally: `DataCustodianApplicationH2Test` boots the full context, and the codec + producer wire-contract tests pass.