### PR TITLE
fix: local sandbox bring-up — DC↔AS introspection alignment + TP atomMarshaller (#146)

### DIFF
--- a/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/config/AuthorizationServerConfig.java
+++ b/openespi-authserver/src/main/java/org/greenbuttonalliance/espi/authserver/config/AuthorizationServerConfig.java
@@ -326,8 +326,26 @@ public class AuthorizationServerConfig {
                     .build())
                 .build();
 
+        // DataCustodian resource-server introspection client. The DC resource server calls
+        // POST /oauth2/introspect with these credentials (client_secret_basic) to validate opaque
+        // tokens; any registered confidential client may introspect. Matches DC's default
+        // espi.authorization-server.client-id / client-secret (datacustodian / datacustodian-secret),
+        // so the local sandbox introspects out of the box.
+        RegisteredClient dataCustodianIntrospection = RegisteredClient.withId(UUID.randomUUID().toString())
+                .clientId("datacustodian")
+                .clientName("DataCustodian Introspection")
+                .clientSecret("{noop}datacustodian-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .clientIdIssuedAt(Instant.now())
+                .clientSettings(ClientSettings.builder()
+                    .requireAuthorizationConsent(false)
+                    .build())
+                .build();
+
         // Seed default clients, and reconcile existing ones to the code definition (see below).
-        initializeDefaultClients(repository, datacustodianAdmin, thirdPartyClient, thirdPartyAdmin);
+        initializeDefaultClients(repository, datacustodianAdmin, thirdPartyClient, thirdPartyAdmin,
+                dataCustodianIntrospection);
 
         return repository;
     }

--- a/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/MySqlTestcontainersIntegrationTest.java
+++ b/openespi-authserver/src/test/java/org/greenbuttonalliance/espi/authserver/integration/MySqlTestcontainersIntegrationTest.java
@@ -263,7 +263,7 @@ class MySqlTestcontainersIntegrationTest {
             List<String> allClientIds = registeredClientAdminDao.findAllClientIds();
 
             // Then
-            assertThat(allClientIds).hasSize(5); // 2 test clients + 3 default clients
+            assertThat(allClientIds).hasSize(6); // 2 test clients + 4 default clients (incl. datacustodian introspection)
             assertThat(allClientIds).contains("test-client-1", "test-client-2");
         }
 

--- a/openespi-datacustodian/src/main/resources/application-dev-mysql.yml
+++ b/openespi-datacustodian/src/main/resources/application-dev-mysql.yml
@@ -46,5 +46,8 @@ espi:
   datacustodian:
     base-url: http://localhost:8081/DataCustodian
   authorization-server:
-    issuer-uri: http://localhost:8080
-    jwk-set-uri: http://localhost:8080/.well-known/jwks.json
+    # Local sandbox AS runs on :9999. Opaque-token introspection (ESPI standard) points here;
+    # client-id/secret default to datacustodian/datacustodian-secret (seeded on the AS).
+    issuer-uri: http://localhost:9999
+    introspection-endpoint: http://localhost:9999/oauth2/introspect
+    jwk-set-uri: http://localhost:9999/.well-known/jwks.json  # unused (opaque tokens; no JWT/JWK)

--- a/openespi-thirdparty/src/main/java/org/greenbuttonalliance/espi/thirdparty/config/JaxbMarshallingConfiguration.java
+++ b/openespi-thirdparty/src/main/java/org/greenbuttonalliance/espi/thirdparty/config/JaxbMarshallingConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *        Copyright (c) 2025 Green Button Alliance, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.greenbuttonalliance.espi.thirdparty.config;
+
+import jakarta.xml.bind.Marshaller;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+
+import java.util.Map;
+
+/**
+ * JAXB marshalling configuration for the Third Party.
+ *
+ * <p>Defines the {@code atomMarshaller} {@link Jaxb2Marshaller} that the resource-fetch layer
+ * (e.g. {@code ResourceRESTRepositoryImpl}) requires to (un)marshal ESPI Atom feeds/entries fetched
+ * from the Data Custodian. The bean was missing, so the TP context failed to start (#146); this
+ * supplies it, scanning the shared ESPI DTO (JAXB) packages — the same context the Data Custodian's
+ * marshaller uses.</p>
+ */
+@Configuration
+public class JaxbMarshallingConfiguration {
+
+    @Bean(name = "atomMarshaller")
+    public Jaxb2Marshaller atomMarshaller() {
+        Jaxb2Marshaller marshaller = new Jaxb2Marshaller();
+        // Domain entities carry no JAXB annotations (per the project's JPA/JAXB separation rule);
+        // the JAXB-annotated DTOs (incl. the Atom envelope DTOs) live under common.dto.
+        marshaller.setPackagesToScan(
+                "org.greenbuttonalliance.espi.common.domain",
+                "org.greenbuttonalliance.espi.common.dto");
+        marshaller.setMarshallerProperties(Map.of(
+                Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE,
+                Marshaller.JAXB_ENCODING, "UTF-8"));
+        return marshaller;
+    }
+}


### PR DESCRIPTION
Surfaced by manually launching all three servers (AS + DC + TP) against a local MySQL (the "test all three servers" exercise). Two dev-bring-up blockers fixed; findings recorded.

## 1. DC↔AS opaque-token introspection (dev was broken)
DC defaulted to introspect at `http://localhost:8080` with client `datacustodian`/`datacustodian-secret` — but the AS runs on **:9999** and had **no `datacustodian` client** seeded → `Connection refused` → every token **401'd at the DC**.
- **AS**: seed a dedicated `datacustodian`/`{noop}datacustodian-secret` introspection client (`client_secret_basic`) — a confidential client any of whose role is just to let the DC resource-server introspect; matches DC's default introspection client-id/secret so the sandbox works out of the box. Seeded-client assertion in `MySqlTestcontainersIntegrationTest` bumped 5→6.
- **DC** `application-dev-mysql.yml`: point `issuer-uri` + `introspection-endpoint` at the local AS `:9999`.
- **Verified end-to-end:** `client_credentials` token mint → `/oauth2/introspect` (`active:true`) → DC authorizes the request (reaches the controller). *The subsequent 500 is a separate pre-existing bug — collection controllers marshal a raw `List` instead of an Atom `<feed>` — which the #119 E-phase entry/feed assembly fixes.*

## 2. TP #146 — missing `atomMarshaller` bean
`ResourceRESTRepositoryImpl` requires a `Jaxb2Marshaller @Qualifier("atomMarshaller")` that didn't exist → TP `APPLICATION FAILED TO START`. Added `JaxbMarshallingConfiguration` defining it (scanning the shared `common.domain`/`common.dto` packages, same context the DC marshaller uses). **TP now advances past this bean.**

Full TP boot remains blocked on the **deeper #146 chain** — the next gap is the custom `ResourceRepository` interface, which has **no implementation anywhere** (the resource-fetch layer was never built). That's substantive TP work ("TP last") and out of scope here; documented on #146.

## Bring-up status after this PR
- **AS (9999)** ✅ boots; token mint + introspection work.
- **DC (8081)** ✅ boots; introspection now succeeds against the AS.
- **TP (8082)** ⏳ advances past atomMarshaller; full boot tracked in #146.

No production behavior change (DC change is dev-profile only; AS adds one seeded client; TP adds a bean). TP has no `@SpringBootTest` context test (its integration test's `@SpringBootTest` is commented out), so the new bean has no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)