### PR TITLE
fix(#171): re-enable CustodianHomeController so post-login /custodian/home doesn't 401

### DIFF
--- a/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/custodian/CustodianHomeController.java
+++ b/openespi-datacustodian/src/main/java/org/greenbuttonalliance/espi/datacustodian/web/custodian/CustodianHomeController.java
@@ -23,8 +23,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-// @Controller - COMMENTED OUT: UI not needed in resource server
-// @Component
+// The custodian login flow (C2a) redirects to /custodian/home on success
+// (CustomerLoginSecurityConfiguration DEFAULT_SUCCESS_URL), so this landing controller must be
+// enabled — otherwise the post-login redirect 404s and is re-dispatched to /error, which the
+// resource-server chain returns as 401. Template: templates/custodian/home.html.
+@Controller
 @RequestMapping("/custodian/home")
 public class CustodianHomeController {
 


### PR DESCRIPTION
Closes #171.

Custodian login (admin/admin, dev) succeeds but the post-login redirect to /custodian/home returned **401**. Root cause: CustodianHomeController's @Controller annotation was commented out, so /custodian/home had no handler -> 404 -> re-dispatched to /error -> the resource-server filter chain evaluated it anonymously -> 401. Re-enabled @Controller; the templates/custodian/home.html view already exists.

The C2a login work set the form-login DEFAULT_SUCCESS_URL to /custodian/home but the landing controller was left disabled — this reconciles them. One-line change plus an explanatory comment. Surfaced during the local sandbox bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)